### PR TITLE
fix: complete FakeMetricsManager.Dispose implementation

### DIFF
--- a/src/Shared/Avalon.Metrics/FakeMetricsManager.cs
+++ b/src/Shared/Avalon.Metrics/FakeMetricsManager.cs
@@ -39,6 +39,6 @@ public class FakeMetricsManager : IMetricsManager
 
     public void Dispose()
     {
-        // TODO release managed resources here
+        // No managed or unmanaged resources to release — intentional no-op stub.
     }
 }

--- a/tests/Avalon.Shared.UnitTests/Metrics/FakeMetricsManagerShould.cs
+++ b/tests/Avalon.Shared.UnitTests/Metrics/FakeMetricsManagerShould.cs
@@ -6,7 +6,7 @@ namespace Avalon.Shared.UnitTests.Metrics;
 public class FakeMetricsManagerShould
 {
     [Fact]
-    public void Should_NotThrow_WhenDisposedOnce()
+    public void NotThrowWhenDisposedOnce()
     {
         var sut = new FakeMetricsManager();
         var ex = Record.Exception(() => sut.Dispose());
@@ -14,7 +14,7 @@ public class FakeMetricsManagerShould
     }
 
     [Fact]
-    public void Should_NotThrow_WhenDisposedTwice()
+    public void NotThrowWhenDisposedTwice()
     {
         var sut = new FakeMetricsManager();
         sut.Dispose();
@@ -23,7 +23,7 @@ public class FakeMetricsManagerShould
     }
 
     [Fact]
-    public void Should_RemainCallable_AfterDispose()
+    public void RemainCallableAfterDispose()
     {
         var sut = new FakeMetricsManager();
         sut.Dispose();
@@ -35,7 +35,7 @@ public class FakeMetricsManagerShould
             sut.QueueEvent("e", "v");
             sut.QueueMetric("m", "v");
             sut.QueueMetric("m", 1.0);
-            sut.QueueMetric("m", new byte[] { 0x01 });
+            sut.QueueMetric("m", [0x01]);
             sut.SetDefaultProperties(new Dictionary<string, string>());
         });
 

--- a/tests/Avalon.Shared.UnitTests/Metrics/FakeMetricsManagerShould.cs
+++ b/tests/Avalon.Shared.UnitTests/Metrics/FakeMetricsManagerShould.cs
@@ -1,0 +1,44 @@
+using Avalon.Metrics;
+using Xunit;
+
+namespace Avalon.Shared.UnitTests.Metrics;
+
+public class FakeMetricsManagerShould
+{
+    [Fact]
+    public void Should_NotThrow_WhenDisposedOnce()
+    {
+        var sut = new FakeMetricsManager();
+        var ex = Record.Exception(() => sut.Dispose());
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void Should_NotThrow_WhenDisposedTwice()
+    {
+        var sut = new FakeMetricsManager();
+        sut.Dispose();
+        var ex = Record.Exception(() => sut.Dispose());
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void Should_RemainCallable_AfterDispose()
+    {
+        var sut = new FakeMetricsManager();
+        sut.Dispose();
+
+        var ex = Record.Exception(() =>
+        {
+            sut.Start();
+            sut.Stop();
+            sut.QueueEvent("e", "v");
+            sut.QueueMetric("m", "v");
+            sut.QueueMetric("m", 1.0);
+            sut.QueueMetric("m", new byte[] { 0x01 });
+            sut.SetDefaultProperties(new Dictionary<string, string>());
+        });
+
+        Assert.Null(ex);
+    }
+}


### PR DESCRIPTION
## Summary

- Replaces the `// TODO release managed resources here` stub in `FakeMetricsManager.Dispose()` with an explicit `// No managed or unmanaged resources to release — intentional no-op stub.` comment
- Audited all fields — the class holds none, so the empty body is the correct implementation
- Adds `FakeMetricsManagerShould` with 3 tests covering idempotent disposal and post-dispose callability

## Test plan

- [ ] `NotThrowWhenDisposedOnce` — first `Dispose()` call does not throw
- [ ] `NotThrowWhenDisposedTwice` — second `Dispose()` call does not throw (idempotent)
- [ ] `RemainCallableAfterDispose` — all public methods remain callable after disposal

Closes #170