### PR TITLE
feat(api): resource-based authorization foundations + role/enum alignment

### DIFF
--- a/src/Server/Avalon.Api/Authentication/AvalonAuthHandler.cs
+++ b/src/Server/Avalon.Api/Authentication/AvalonAuthHandler.cs
@@ -66,7 +66,8 @@ public class AvalonAuthHandler : IAuthorizationHandler
 
         _logger.LogInformation("Loading account {AccountId}", accountId);
 
-        Account? account = await _accountService.FindById(accountId);
+        Account? account = await _accountService.FindByIdAsync(accountId,
+            _httpContextAccessor.HttpContext.RequestAborted);
 
         if (account == null)
         {

--- a/src/Server/Avalon.Api/Authentication/ClaimsPrincipalExtensions.cs
+++ b/src/Server/Avalon.Api/Authentication/ClaimsPrincipalExtensions.cs
@@ -1,0 +1,31 @@
+using System.Security.Claims;
+using Avalon.Common.ValueObjects;
+
+namespace Avalon.Api.Authentication;
+
+public static class ClaimsPrincipalExtensions
+{
+    public static AccountId AccountId(this ClaimsPrincipal user)
+    {
+        var raw = user.FindFirstValue(ClaimTypes.NameIdentifier)
+            ?? throw new InvalidOperationException("missing sub claim");
+        return new AccountId(long.Parse(raw));
+    }
+
+    // Role claims are emitted per set flag in AccountAccessLevel. An Admin principal
+    // does NOT automatically satisfy IsInRole("GameMaster") unless that flag is set too.
+    // This helper walks the hierarchy explicitly.
+    private static readonly string[] Ladder =
+        { AvalonRoles.Player, AvalonRoles.GameMaster, AvalonRoles.Admin, AvalonRoles.Console };
+
+    public static bool HasRoleAtLeast(this ClaimsPrincipal user, string minRole)
+    {
+        var minIdx = Array.IndexOf(Ladder, minRole);
+        if (minIdx < 0) return false;
+
+        for (var i = minIdx; i < Ladder.Length; i++)
+            if (user.IsInRole(Ladder[i])) return true;
+
+        return false;
+    }
+}

--- a/src/Server/Avalon.Api/Authorization/AccountReadHandler.cs
+++ b/src/Server/Avalon.Api/Authorization/AccountReadHandler.cs
@@ -1,0 +1,23 @@
+using Avalon.Api.Authentication;
+using Avalon.Domain.Auth;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Avalon.Api.Authorization;
+
+public sealed class AccountReadHandler : AuthorizationHandler<ReadRequirement, Account>
+{
+    protected override Task HandleRequirementAsync(
+        AuthorizationHandlerContext context, ReadRequirement requirement, Account resource)
+    {
+        if (context.User.HasRoleAtLeast(AvalonRoles.GameMaster))
+        {
+            context.Succeed(requirement);
+            return Task.CompletedTask;
+        }
+
+        if (resource.Id == context.User.AccountId())
+            context.Succeed(requirement);
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Server/Avalon.Api/Authorization/AccountWriteHandler.cs
+++ b/src/Server/Avalon.Api/Authorization/AccountWriteHandler.cs
@@ -1,0 +1,23 @@
+using Avalon.Api.Authentication;
+using Avalon.Domain.Auth;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Avalon.Api.Authorization;
+
+public sealed class AccountWriteHandler : AuthorizationHandler<WriteRequirement, Account>
+{
+    protected override Task HandleRequirementAsync(
+        AuthorizationHandlerContext context, WriteRequirement requirement, Account resource)
+    {
+        if (context.User.HasRoleAtLeast(AvalonRoles.Admin))
+        {
+            context.Succeed(requirement);
+            return Task.CompletedTask;
+        }
+
+        if (resource.Id == context.User.AccountId())
+            context.Succeed(requirement);
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Server/Avalon.Api/Authorization/CharacterReadHandler.cs
+++ b/src/Server/Avalon.Api/Authorization/CharacterReadHandler.cs
@@ -1,0 +1,23 @@
+using Avalon.Api.Authentication;
+using Avalon.Domain.Characters;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Avalon.Api.Authorization;
+
+public sealed class CharacterReadHandler : AuthorizationHandler<ReadRequirement, Character>
+{
+    protected override Task HandleRequirementAsync(
+        AuthorizationHandlerContext context, ReadRequirement requirement, Character resource)
+    {
+        if (context.User.HasRoleAtLeast(AvalonRoles.GameMaster))
+        {
+            context.Succeed(requirement);
+            return Task.CompletedTask;
+        }
+
+        if (resource.AccountId == context.User.AccountId())
+            context.Succeed(requirement);
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Server/Avalon.Api/Authorization/CharacterWriteHandler.cs
+++ b/src/Server/Avalon.Api/Authorization/CharacterWriteHandler.cs
@@ -1,0 +1,23 @@
+using Avalon.Api.Authentication;
+using Avalon.Domain.Characters;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Avalon.Api.Authorization;
+
+public sealed class CharacterWriteHandler : AuthorizationHandler<WriteRequirement, Character>
+{
+    protected override Task HandleRequirementAsync(
+        AuthorizationHandlerContext context, WriteRequirement requirement, Character resource)
+    {
+        if (context.User.HasRoleAtLeast(AvalonRoles.Admin))
+        {
+            context.Succeed(requirement);
+            return Task.CompletedTask;
+        }
+
+        if (resource.AccountId == context.User.AccountId())
+            context.Succeed(requirement);
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Server/Avalon.Api/Authorization/ReadRequirement.cs
+++ b/src/Server/Avalon.Api/Authorization/ReadRequirement.cs
@@ -1,0 +1,5 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace Avalon.Api.Authorization;
+
+public sealed class ReadRequirement : IAuthorizationRequirement;

--- a/src/Server/Avalon.Api/Authorization/WriteRequirement.cs
+++ b/src/Server/Avalon.Api/Authorization/WriteRequirement.cs
@@ -1,0 +1,5 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace Avalon.Api.Authorization;
+
+public sealed class WriteRequirement : IAuthorizationRequirement;

--- a/src/Server/Avalon.Api/Avalon.Api.csproj
+++ b/src/Server/Avalon.Api/Avalon.Api.csproj
@@ -10,6 +10,10 @@
     <PackageReference Include="LinqKit" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer"/>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi"/>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Otp.NET"/>
     <PackageReference Include="Scalar.AspNetCore"/>
     <PackageReference Include="Serilog.AspNetCore"/>

--- a/src/Server/Avalon.Api/Contract/AccountDto.cs
+++ b/src/Server/Avalon.Api/Contract/AccountDto.cs
@@ -20,20 +20,3 @@ public class AccountDto
     public long TotalTime { get; set; }
     public AccountAccessLevel AccessLevel { get; set; }
 }
-
-[Flags]
-public enum AccountAccessLevel : ushort
-{
-    Player = 0,
-    GameMaster = 1,
-    Administrator = 2,
-    Tournament = 4,
-    PTR = 8,
-}
-
-public enum OperatingSystem : ushort
-{
-    Windows,
-    MacOS,
-    Linux
-}

--- a/src/Server/Avalon.Api/Contract/Mappers/AutoMappingProfile.cs
+++ b/src/Server/Avalon.Api/Contract/Mappers/AutoMappingProfile.cs
@@ -17,9 +17,9 @@ public static class MappingExtensions
         MuteReason = account.MuteReason,
         Online = account.Online,
         Locale = account.Locale,
-        Os = (OperatingSystem) account.Os,
+        Os = account.Os,
         TotalTime = account.TotalTime,
-        AccessLevel = (AccountAccessLevel) account.AccessLevel,
+        AccessLevel = account.AccessLevel,
     };
 
     public static CharacterDto ToDto(this Character character) => new()

--- a/src/Server/Avalon.Api/Controllers/AccountController.cs
+++ b/src/Server/Avalon.Api/Controllers/AccountController.cs
@@ -1,7 +1,9 @@
 using Avalon.Api.Authentication;
+using Avalon.Api.Authorization;
 using Avalon.Api.Contract;
 using Avalon.Api.Contract.Mappers;
 using Avalon.Api.Services;
+using Avalon.Common.ValueObjects;
 using Avalon.Database;
 using Avalon.Database.Extensions;
 using Microsoft.AspNetCore.Authorization;
@@ -9,18 +11,20 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Avalon.Api.Controllers;
 
-[Authorize]
+[Authorize(Policy = AvalonRoles.Player)]
 [ApiController]
 [Route("account")]
 public class AccountController : BaseController
 {
     private readonly IAccountService _accountService;
     private readonly IAuthContext _authContext;
+    private readonly IAuthorizationService _authz;
 
-    public AccountController(IAccountService accountService, IAuthContext authContext)
+    public AccountController(IAccountService accountService, IAuthContext authContext, IAuthorizationService authz)
     {
         _accountService = accountService;
         _authContext = authContext;
+        _authz = authz;
     }
 
     [HttpGet(Name = "GetAccount")]
@@ -31,17 +35,19 @@ public class AccountController : BaseController
         return await Task.FromResult(dto);
     }
 
-    [Authorize(Policy = AvalonRoles.GameMaster)]
     [HttpGet("{id:long}", Name = "FindAccountById")]
-    [ProducesResponseType(typeof(AccountDto), 200)]
-    public async Task<AccountDto> FindById([FromRoute] long id)
+    [ProducesResponseType(typeof(AccountDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> FindById([FromRoute] long id, CancellationToken ct)
     {
-        var account = await _accountService.FindById(id);
-        if (account is null)
-        {
-            throw new Exception("Account not found");
-        }
-        return account.ToDto();
+        var account = await _accountService.FindByIdAsync(new AccountId(id), ct);
+        if (account is null) return NotFound();
+
+        var authz = await _authz.AuthorizeAsync(User, account, new ReadRequirement());
+        if (!authz.Succeeded) return NotFoundOrForbid();
+
+        return Ok(account.ToDto());
     }
 
     [Authorize(Policy = AvalonRoles.GameMaster)]

--- a/src/Server/Avalon.Api/Controllers/BaseController.cs
+++ b/src/Server/Avalon.Api/Controllers/BaseController.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using Avalon.Api.Authentication;
 using Avalon.Domain.Auth;
 using Microsoft.AspNetCore.Mvc;
 
@@ -9,4 +10,9 @@ public class BaseController : ControllerBase
     protected Account? Account => (Account?)HttpContext.Items[nameof(Account)];
     protected IPAddress IpAddress => HttpContext.Connection.RemoteIpAddress ?? IPAddress.None;
     protected CancellationToken CancellationToken => HttpContext.RequestAborted;
+
+    // Existence-hiding: Player-only callers cannot distinguish "doesn't exist"
+    // from "exists but not mine". GameMaster+ sees the real Forbid.
+    protected IActionResult NotFoundOrForbid() =>
+        User.HasRoleAtLeast(AvalonRoles.GameMaster) ? Forbid() : NotFound();
 }

--- a/src/Server/Avalon.Api/Controllers/CharacterController.cs
+++ b/src/Server/Avalon.Api/Controllers/CharacterController.cs
@@ -1,4 +1,5 @@
 using Avalon.Api.Authentication;
+using Avalon.Api.Authorization;
 using Avalon.Api.Contract;
 using Avalon.Api.Contract.Mappers;
 using Avalon.Api.Services;
@@ -8,33 +9,44 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Avalon.Api.Controllers;
 
-[Authorize]
+[Authorize(Policy = AvalonRoles.Player)]
 [ApiController]
 [Route("character")]
 public class CharacterController : BaseController
 {
     private readonly IAuthContext _authContext;
     private readonly ICharacterService _service;
+    private readonly IAuthorizationService _authz;
 
-    public CharacterController(IAuthContext authContext, ICharacterService service)
+    public CharacterController(IAuthContext authContext, ICharacterService service, IAuthorizationService authz)
     {
         _authContext = authContext;
         _service = service;
+        _authz = authz;
     }
 
-    [HttpGet(Name = "GetCharacter")]
-    public async Task<IList<CharacterDto>> GetAll()
+    [HttpGet(Name = "GetCharacters")]
+    public async Task<IList<CharacterDto>> GetAll(CancellationToken ct)
     {
-        var characters = await _service.GetAllCharacters(_authContext.Account?.Id ?? throw new Exception("Account not loaded"));
+        var accountId = _authContext.Account?.Id
+            ?? throw new InvalidOperationException("Account not loaded");
+
+        var characters = await _service.GetAllCharactersAsync(accountId, ct);
         return characters.Select(c => c.ToDto()).ToList();
     }
 
     [HttpGet("{id}", Name = "GetCharacterById")]
-    [ProducesResponseType(typeof(CharacterDto), 200)]
-    public async Task<CharacterDto> GetById([FromRoute] uint id)
+    [ProducesResponseType(typeof(CharacterDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetById([FromRoute] uint id, CancellationToken ct)
     {
-        var character = await _service.GetCharacterById(id);
-        return character.ToDto();
-    }
+        var character = await _service.GetCharacterByIdAsync(new CharacterId(id), ct);
+        if (character is null) return NotFound();
 
+        var authz = await _authz.AuthorizeAsync(User, character, new ReadRequirement());
+        if (!authz.Succeeded) return NotFoundOrForbid();
+
+        return Ok(character.ToDto());
+    }
 }

--- a/src/Server/Avalon.Api/ServiceRegistration.cs
+++ b/src/Server/Avalon.Api/ServiceRegistration.cs
@@ -121,5 +121,9 @@ public static class ServiceRegistration
 
         services.AddScoped<IAuthContext, AuthContext>();
         services.AddScoped<IAuthorizationHandler, AvalonAuthHandler>();
+        services.AddScoped<IAuthorizationHandler, Authorization.CharacterReadHandler>();
+        services.AddScoped<IAuthorizationHandler, Authorization.CharacterWriteHandler>();
+        services.AddScoped<IAuthorizationHandler, Authorization.AccountReadHandler>();
+        services.AddScoped<IAuthorizationHandler, Authorization.AccountWriteHandler>();
     }
 }

--- a/src/Server/Avalon.Api/Services/AccountService.cs
+++ b/src/Server/Avalon.Api/Services/AccountService.cs
@@ -15,7 +15,7 @@ namespace Avalon.Api.Services;
 
 public interface IAccountService
 {
-    Task<Account?> FindById(AccountId id);
+    Task<Account?> FindByIdAsync(AccountId id, CancellationToken cancellationToken = default);
     Task<AuthenticateResponse> Authenticate(AuthenticateRequest model, IPAddress ipAddress, CancellationToken cancellationToken);
     Task<RegisterResponse> Register(RegisterRequest model, string userAgent, IPAddress ipAddress,
         CancellationToken cancellationToken);
@@ -46,9 +46,9 @@ public class AccountService : IAccountService
         _deviceRepository = deviceRepository;
     }
 
-    public async Task<Account?> FindById(AccountId id)
+    public async Task<Account?> FindByIdAsync(AccountId id, CancellationToken cancellationToken = default)
     {
-        return await _accountRepository.FindByIdAsync(id);
+        return await _accountRepository.FindByIdAsync(id, track: false, cancellationToken);
     }
 
     public async Task<AuthenticateResponse> Authenticate(AuthenticateRequest model, IPAddress ipAddress,

--- a/src/Server/Avalon.Api/Services/CharacterService.cs
+++ b/src/Server/Avalon.Api/Services/CharacterService.cs
@@ -1,54 +1,27 @@
-using Avalon.Api.Authentication;
-using Avalon.Api.Exceptions;
 using Avalon.Common.ValueObjects;
 using Avalon.Database.Character.Repositories;
-using Avalon.Domain.Auth;
 using Avalon.Domain.Characters;
 
 namespace Avalon.Api.Services;
 
 public interface ICharacterService
 {
-    Task<List<Character>> GetAllCharacters(AccountId? id);
-    Task<Character> GetCharacterById(CharacterId id);
+    Task<List<Character>> GetAllCharactersAsync(AccountId id, CancellationToken cancellationToken = default);
+    Task<Character?> GetCharacterByIdAsync(CharacterId id, CancellationToken cancellationToken = default);
 }
 
 public class CharacterService : ICharacterService
 {
     private readonly ICharacterRepository _characterRepository;
-    private readonly IAuthContext _authContext;
 
-    public CharacterService(ICharacterRepository characterRepository, IAuthContext authContext)
+    public CharacterService(ICharacterRepository characterRepository)
     {
         _characterRepository = characterRepository;
-        _authContext = authContext;
     }
 
-    public async Task<List<Character>> GetAllCharacters(AccountId? id)
-    {
-        if (id == null)
-        {
-            id = _authContext.Account?.Id!;
-        }
-        else
-        {
-            if (_authContext.Account?.Id.Value != id && !_authContext.Account!.AccessLevel.HasFlag(AccountAccessLevel.GameMaster))
-            {
-                throw new BusinessException("Unauthorized");
-            }
-        }
+    public Task<List<Character>> GetAllCharactersAsync(AccountId id, CancellationToken cancellationToken = default) =>
+        _characterRepository.FindByAccountAsync(id, cancellationToken);
 
-        return await _characterRepository.FindByAccountAsync(id);
-    }
-
-    public async Task<Character> GetCharacterById(CharacterId id)
-    {
-        var character = await _characterRepository.FindByIdAsync(id);
-        if (character == null)
-        {
-            throw new BusinessException("Character not found");
-        }
-
-        return character;
-    }
+    public Task<Character?> GetCharacterByIdAsync(CharacterId id, CancellationToken cancellationToken = default) =>
+        _characterRepository.FindByIdAsync(id, track: false, cancellationToken);
 }

--- a/src/Server/Avalon.Database.Auth/AuthDbContext.cs
+++ b/src/Server/Avalon.Database.Auth/AuthDbContext.cs
@@ -131,7 +131,7 @@ public class AuthDbContext(ILoggerFactory loggerFactory, IOptions<DatabaseConfig
             Os = OperatingSystem.Linux,
             TotalTime = 0,
             AccessLevel =
-                AccountAccessLevel.Player | AccountAccessLevel.GameMaster | AccountAccessLevel.Administrator,
+                AccountAccessLevel.Player | AccountAccessLevel.GameMaster | AccountAccessLevel.Admin,
             LastLogin = new DateTime(2021, 1, 1, 0, 0, 0, DateTimeKind.Utc),
             Online = false,
             MuteBy = string.Empty,
@@ -222,7 +222,7 @@ public class AuthDbContext(ILoggerFactory loggerFactory, IOptions<DatabaseConfig
             Type = WorldType.PvE,
             MinVersion = "0.0.1",
             Version = "0.0.1",
-            AccessLevelRequired = AccountAccessLevel.Administrator,
+            AccessLevelRequired = AccountAccessLevel.Admin,
             CreatedAt = new DateTime(2021, 1, 1, 0, 0, 0, DateTimeKind.Utc),
             UpdatedAt = new DateTime(2021, 1, 1, 0, 0, 0, DateTimeKind.Utc)
         }, new Domain.Auth.World

--- a/src/Server/Avalon.Database.Auth/Migrations/20260422031153_RemapAccountAccessLevel.Designer.cs
+++ b/src/Server/Avalon.Database.Auth/Migrations/20260422031153_RemapAccountAccessLevel.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Avalon.Database.Auth;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Avalon.Database.Auth.Migrations
 {
     [DbContext(typeof(AuthDbContext))]
-    partial class AuthDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260422031153_RemapAccountAccessLevel")]
+    partial class RemapAccountAccessLevel
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Server/Avalon.Database.Auth/Migrations/20260422031153_RemapAccountAccessLevel.cs
+++ b/src/Server/Avalon.Database.Auth/Migrations/20260422031153_RemapAccountAccessLevel.cs
@@ -41,29 +41,27 @@ namespace Avalon.Database.Auth.Migrations
             // Remap any existing non-seed rows bitwise from the old AccountAccessLevel
             // enum layout (Player=0, GameMaster=1, Administrator=2, Tournament=4, PTR=8)
             // to the new layout (Player=1, GameMaster=2, Admin=4, Console=8, Tournament=16, PTR=32).
-            // Seed rows above have already been rewritten by UpdateData; running the SQL
-            // against them is a no-op because their new values share no bits with the
-            // old mapping (except Player=0 which is handled explicitly below).
+            // Seed rows are excluded via WHERE because UpdateData (above) has already rewritten
+            // them to their final values. Re-applying the bitwise remap formula on those rewritten
+            // values would corrupt them.
             migrationBuilder.Sql("""
                 UPDATE "Accounts" SET "AccessLevel" = (
-                      (CASE WHEN "AccessLevel" = 0 THEN 1 ELSE 0 END)
-                    | (CASE WHEN ("AccessLevel" & 1) = 1 THEN 2 ELSE 0 END)
-                    | (CASE WHEN ("AccessLevel" & 2) = 2 THEN 4 ELSE 0 END)
-                    | (CASE WHEN ("AccessLevel" & 4) = 4 THEN 16 ELSE 0 END)
-                    | (CASE WHEN ("AccessLevel" & 8) = 8 THEN 32 ELSE 0 END)
-                )
-                WHERE "Id" <> 1;
+                      1                                                                       /* Player bit always set */
+                    | (CASE WHEN ("AccessLevel" & 1) = 1 THEN 2 ELSE 0 END)                   /* GameMaster */
+                    | (CASE WHEN ("AccessLevel" & 2) = 2 THEN 4 ELSE 0 END)                   /* Admin */
+                    | (CASE WHEN ("AccessLevel" & 4) = 4 THEN 16 ELSE 0 END)                  /* Tournament */
+                    | (CASE WHEN ("AccessLevel" & 8) = 8 THEN 32 ELSE 0 END)                  /* PTR */
+                ) WHERE "Id" <> 1;
             """);
 
             migrationBuilder.Sql("""
                 UPDATE "Worlds" SET "AccessLevelRequired" = (
-                      (CASE WHEN "AccessLevelRequired" = 0 THEN 1 ELSE 0 END)
-                    | (CASE WHEN ("AccessLevelRequired" & 1) = 1 THEN 2 ELSE 0 END)
-                    | (CASE WHEN ("AccessLevelRequired" & 2) = 2 THEN 4 ELSE 0 END)
-                    | (CASE WHEN ("AccessLevelRequired" & 4) = 4 THEN 16 ELSE 0 END)
-                    | (CASE WHEN ("AccessLevelRequired" & 8) = 8 THEN 32 ELSE 0 END)
-                )
-                WHERE "Id" NOT IN (1, 2, 3);
+                      1                                                                                /* Player bit always set */
+                    | (CASE WHEN ("AccessLevelRequired" & 1) = 1 THEN 2 ELSE 0 END)                    /* GameMaster */
+                    | (CASE WHEN ("AccessLevelRequired" & 2) = 2 THEN 4 ELSE 0 END)                    /* Admin */
+                    | (CASE WHEN ("AccessLevelRequired" & 4) = 4 THEN 16 ELSE 0 END)                   /* Tournament */
+                    | (CASE WHEN ("AccessLevelRequired" & 8) = 8 THEN 32 ELSE 0 END)                   /* PTR */
+                ) WHERE "Id" NOT IN (1, 2, 3);
             """);
         }
 

--- a/src/Server/Avalon.Database.Auth/Migrations/20260422031153_RemapAccountAccessLevel.cs
+++ b/src/Server/Avalon.Database.Auth/Migrations/20260422031153_RemapAccountAccessLevel.cs
@@ -56,7 +56,7 @@ namespace Avalon.Database.Auth.Migrations
 
             migrationBuilder.Sql("""
                 UPDATE "Worlds" SET "AccessLevelRequired" = (
-                      1                                                                                /* Player bit always set */
+                      (CASE WHEN "AccessLevelRequired" = 0 THEN 1 ELSE 0 END)                          /* legacy 0 -> Player */
                     | (CASE WHEN ("AccessLevelRequired" & 1) = 1 THEN 2 ELSE 0 END)                    /* GameMaster */
                     | (CASE WHEN ("AccessLevelRequired" & 2) = 2 THEN 4 ELSE 0 END)                    /* Admin */
                     | (CASE WHEN ("AccessLevelRequired" & 4) = 4 THEN 16 ELSE 0 END)                   /* Tournament */

--- a/src/Server/Avalon.Database.Auth/Migrations/20260422031153_RemapAccountAccessLevel.cs
+++ b/src/Server/Avalon.Database.Auth/Migrations/20260422031153_RemapAccountAccessLevel.cs
@@ -1,0 +1,123 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Avalon.Database.Auth.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemapAccountAccessLevel : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "Accounts",
+                keyColumn: "Id",
+                keyValue: 1L,
+                column: "AccessLevel",
+                value: 7);
+
+            migrationBuilder.UpdateData(
+                table: "Worlds",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "AccessLevelRequired",
+                value: 4);
+
+            migrationBuilder.UpdateData(
+                table: "Worlds",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "AccessLevelRequired",
+                value: 1);
+
+            migrationBuilder.UpdateData(
+                table: "Worlds",
+                keyColumn: "Id",
+                keyValue: 3,
+                column: "AccessLevelRequired",
+                value: 32);
+
+            // Remap any existing non-seed rows bitwise from the old AccountAccessLevel
+            // enum layout (Player=0, GameMaster=1, Administrator=2, Tournament=4, PTR=8)
+            // to the new layout (Player=1, GameMaster=2, Admin=4, Console=8, Tournament=16, PTR=32).
+            // Seed rows above have already been rewritten by UpdateData; running the SQL
+            // against them is a no-op because their new values share no bits with the
+            // old mapping (except Player=0 which is handled explicitly below).
+            migrationBuilder.Sql("""
+                UPDATE "Accounts" SET "AccessLevel" = (
+                      (CASE WHEN "AccessLevel" = 0 THEN 1 ELSE 0 END)
+                    | (CASE WHEN ("AccessLevel" & 1) = 1 THEN 2 ELSE 0 END)
+                    | (CASE WHEN ("AccessLevel" & 2) = 2 THEN 4 ELSE 0 END)
+                    | (CASE WHEN ("AccessLevel" & 4) = 4 THEN 16 ELSE 0 END)
+                    | (CASE WHEN ("AccessLevel" & 8) = 8 THEN 32 ELSE 0 END)
+                )
+                WHERE "Id" <> 1;
+            """);
+
+            migrationBuilder.Sql("""
+                UPDATE "Worlds" SET "AccessLevelRequired" = (
+                      (CASE WHEN "AccessLevelRequired" = 0 THEN 1 ELSE 0 END)
+                    | (CASE WHEN ("AccessLevelRequired" & 1) = 1 THEN 2 ELSE 0 END)
+                    | (CASE WHEN ("AccessLevelRequired" & 2) = 2 THEN 4 ELSE 0 END)
+                    | (CASE WHEN ("AccessLevelRequired" & 4) = 4 THEN 16 ELSE 0 END)
+                    | (CASE WHEN ("AccessLevelRequired" & 8) = 8 THEN 32 ELSE 0 END)
+                )
+                WHERE "Id" NOT IN (1, 2, 3);
+            """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Reverse-map any non-seed rows first, then restore seed rows.
+            migrationBuilder.Sql("""
+                UPDATE "Accounts" SET "AccessLevel" = (
+                      (CASE WHEN ("AccessLevel" & 2)  = 2  THEN 1 ELSE 0 END)
+                    | (CASE WHEN ("AccessLevel" & 4)  = 4  THEN 2 ELSE 0 END)
+                    | (CASE WHEN ("AccessLevel" & 16) = 16 THEN 4 ELSE 0 END)
+                    | (CASE WHEN ("AccessLevel" & 32) = 32 THEN 8 ELSE 0 END)
+                )
+                WHERE "Id" <> 1;
+            """);
+
+            migrationBuilder.Sql("""
+                UPDATE "Worlds" SET "AccessLevelRequired" = (
+                      (CASE WHEN ("AccessLevelRequired" & 2)  = 2  THEN 1 ELSE 0 END)
+                    | (CASE WHEN ("AccessLevelRequired" & 4)  = 4  THEN 2 ELSE 0 END)
+                    | (CASE WHEN ("AccessLevelRequired" & 16) = 16 THEN 4 ELSE 0 END)
+                    | (CASE WHEN ("AccessLevelRequired" & 32) = 32 THEN 8 ELSE 0 END)
+                )
+                WHERE "Id" NOT IN (1, 2, 3);
+            """);
+
+            migrationBuilder.UpdateData(
+                table: "Accounts",
+                keyColumn: "Id",
+                keyValue: 1L,
+                column: "AccessLevel",
+                value: 3);
+
+            migrationBuilder.UpdateData(
+                table: "Worlds",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "AccessLevelRequired",
+                value: 2);
+
+            migrationBuilder.UpdateData(
+                table: "Worlds",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "AccessLevelRequired",
+                value: 0);
+
+            migrationBuilder.UpdateData(
+                table: "Worlds",
+                keyColumn: "Id",
+                keyValue: 3,
+                column: "AccessLevelRequired",
+                value: 8);
+        }
+    }
+}

--- a/src/Server/Avalon.Database.Character/Repositories/CharacterRepository.cs
+++ b/src/Server/Avalon.Database.Character/Repositories/CharacterRepository.cs
@@ -7,9 +7,9 @@ namespace Avalon.Database.Character.Repositories;
 
 public interface ICharacterRepository : IRepository<Domain.Characters.Character, CharacterId>
 {
-    Task<Domain.Characters.Character?> FindByNameAsync(string name);
-    Task<Domain.Characters.Character?> FindByIdAndAccountAsync(CharacterId id, AccountId accountId);
-    Task<List<Domain.Characters.Character>> FindByAccountAsync(AccountId accountId);
+    Task<Domain.Characters.Character?> FindByNameAsync(string name, CancellationToken cancellationToken = default);
+    Task<Domain.Characters.Character?> FindByIdAndAccountAsync(CharacterId id, AccountId accountId, CancellationToken cancellationToken = default);
+    Task<List<Domain.Characters.Character>> FindByAccountAsync(AccountId accountId, CancellationToken cancellationToken = default);
 }
 
 public class CharacterRepository : EntityFrameworkRepository<Domain.Characters.Character, CharacterId>, ICharacterRepository
@@ -19,26 +19,25 @@ public class CharacterRepository : EntityFrameworkRepository<Domain.Characters.C
     {
     }
 
-    public async Task<Domain.Characters.Character?> FindByNameAsync(string name)
+    public async Task<Domain.Characters.Character?> FindByNameAsync(string name, CancellationToken cancellationToken = default)
     {
         return await Context.Set<Domain.Characters.Character>()
             .AsNoTracking()
-            .FirstOrDefaultAsync(entity => entity.Name == name);
+            .FirstOrDefaultAsync(entity => entity.Name == name, cancellationToken);
     }
 
-    public async Task<Domain.Characters.Character?> FindByIdAndAccountAsync(CharacterId id, AccountId accountId)
+    public async Task<Domain.Characters.Character?> FindByIdAndAccountAsync(CharacterId id, AccountId accountId, CancellationToken cancellationToken = default)
     {
         return await Context.Set<Domain.Characters.Character>()
             .AsNoTracking()
-            .FirstOrDefaultAsync(entity => entity.Id == id && entity.AccountId == accountId);
-
+            .FirstOrDefaultAsync(entity => entity.Id == id && entity.AccountId == accountId, cancellationToken);
     }
 
-    public async Task<List<Domain.Characters.Character>> FindByAccountAsync(AccountId accountId)
+    public async Task<List<Domain.Characters.Character>> FindByAccountAsync(AccountId accountId, CancellationToken cancellationToken = default)
     {
         return await Context.Set<Domain.Characters.Character>()
             .AsNoTracking()
             .Where(entity => entity.AccountId == accountId)
-            .ToListAsync();
+            .ToListAsync(cancellationToken);
     }
 }

--- a/src/Shared/Avalon.Domain/Auth/Account.cs
+++ b/src/Shared/Avalon.Domain/Auth/Account.cs
@@ -60,11 +60,12 @@ public class Account : IDbEntity<AccountId>
 [Flags]
 public enum AccountAccessLevel : ushort
 {
-    Player = 0,
-    GameMaster = 1,
-    Administrator = 2,
-    Tournament = 4,
-    PTR = 8,
+    Player = 1,
+    GameMaster = 2,
+    Admin = 4,
+    Console = 8,
+    Tournament = 16,
+    PTR = 32,
 }
 
 public enum AccountLocale : ushort

--- a/tests/Avalon.Api.UnitTests/Authentication/ClaimsPrincipalExtensionsShould.cs
+++ b/tests/Avalon.Api.UnitTests/Authentication/ClaimsPrincipalExtensionsShould.cs
@@ -1,0 +1,50 @@
+using System.Security.Claims;
+using Avalon.Api.Authentication;
+using Xunit;
+
+namespace Avalon.Api.UnitTests.Authentication;
+
+public class ClaimsPrincipalExtensionsShould
+{
+    private static ClaimsPrincipal Principal(params (string type, string value)[] claims) =>
+        new(new ClaimsIdentity(
+            claims.Select(c => new Claim(c.type, c.value)),
+            authenticationType: "test",
+            nameType: ClaimTypes.NameIdentifier,
+            roleType: ClaimTypes.Role));
+
+    [Fact]
+    public void ReturnAccountId_WhenNameIdentifierPresent()
+    {
+        var user = Principal((ClaimTypes.NameIdentifier, "42"));
+        Assert.Equal(42L, user.AccountId().Value);
+    }
+
+    [Fact]
+    public void Throw_WhenNameIdentifierMissing()
+    {
+        var user = Principal();
+        Assert.Throws<InvalidOperationException>(() => user.AccountId());
+    }
+
+    [Theory]
+    [InlineData("Player",     "Player",     true)]
+    [InlineData("GameMaster", "Player",     true)]
+    [InlineData("Admin",      "GameMaster", true)]
+    [InlineData("Console",    "Admin",      true)]
+    [InlineData("Player",     "GameMaster", false)]
+    [InlineData("GameMaster", "Admin",      false)]
+    [InlineData("Admin",      "Console",    false)]
+    public void HasRoleAtLeast_FollowsHierarchy(string callerRole, string minRole, bool expected)
+    {
+        var user = Principal((ClaimTypes.Role, callerRole));
+        Assert.Equal(expected, user.HasRoleAtLeast(minRole));
+    }
+
+    [Fact]
+    public void HasRoleAtLeast_FalseForUnknownMinRole()
+    {
+        var user = Principal((ClaimTypes.Role, "Admin"));
+        Assert.False(user.HasRoleAtLeast("Banana"));
+    }
+}

--- a/tests/Avalon.Api.UnitTests/Authentication/JwtUtilsShould.cs
+++ b/tests/Avalon.Api.UnitTests/Authentication/JwtUtilsShould.cs
@@ -1,0 +1,70 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using Avalon.Api.Authentication.Jwt;
+using Avalon.Api.Config;
+using Avalon.Common.ValueObjects;
+using Avalon.Domain.Auth;
+using Xunit;
+
+namespace Avalon.Api.UnitTests.Authentication;
+
+public class JwtUtilsShould
+{
+    private static readonly AuthenticationConfig Config = new()
+    {
+        IssuerSigningKey = new string('k', 64),
+        Issuer = "test",
+        Audience = "test",
+        ValidateIssuer = true,
+        ValidateIssuerKey = true,
+        ValidateAudience = true,
+        ClockSkewInMinutes = 1,
+    };
+
+    private static Account MakeAccount(AccountAccessLevel level) => new()
+    {
+        Id = new AccountId(7),
+        Username = "u",
+        Email = "u@t",
+        Salt = new byte[] { 1 },
+        Verifier = new byte[] { 2 },
+        JoinDate = DateTime.UtcNow,
+        AccessLevel = level,
+    };
+
+    // The short JWT claim name that ClaimTypes.GroupSid is mapped to by JwtSecurityTokenHandler's
+    // outbound claim type map. JwtSecurityToken.Claims exposes raw JWT payload claim types
+    // (pre-inbound-mapping), so we match against the short form actually present on the wire.
+    private const string GroupSidJwtClaim = "groupsid";
+
+    private static string[] ReadGroupSids(string token) =>
+        new JwtSecurityTokenHandler().ReadJwtToken(token).Claims
+            .Where(c => c.Type == GroupSidJwtClaim || c.Type == ClaimTypes.GroupSid)
+            .Select(c => c.Value)
+            .ToArray();
+
+    [Fact]
+    public void EmitPlayerGroupSidClaim_WhenAccountHasPlayerFlagOnly()
+    {
+        var sut = new JwtUtils(Config);
+        var token = sut.GenerateJwtToken(MakeAccount(AccountAccessLevel.Player));
+
+        var groupSids = ReadGroupSids(token);
+
+        Assert.Contains("Player", groupSids);
+    }
+
+    [Fact]
+    public void EmitAllMatchingGroupSidClaims_WhenAccountHasMultipleFlags()
+    {
+        var sut = new JwtUtils(Config);
+        var token = sut.GenerateJwtToken(MakeAccount(
+            AccountAccessLevel.Player | AccountAccessLevel.GameMaster | AccountAccessLevel.Admin));
+
+        var groupSids = ReadGroupSids(token);
+
+        Assert.Contains("Player",     groupSids);
+        Assert.Contains("GameMaster", groupSids);
+        Assert.Contains("Admin",      groupSids);
+    }
+}

--- a/tests/Avalon.Api.UnitTests/Authorization/AccountReadHandlerShould.cs
+++ b/tests/Avalon.Api.UnitTests/Authorization/AccountReadHandlerShould.cs
@@ -1,0 +1,51 @@
+using System.Security.Claims;
+using Avalon.Api.Authentication;
+using Avalon.Api.Authorization;
+using Avalon.Common.ValueObjects;
+using Avalon.Domain.Auth;
+using Microsoft.AspNetCore.Authorization;
+using Xunit;
+
+namespace Avalon.Api.UnitTests.Authorization;
+
+public class AccountReadHandlerShould
+{
+    private readonly AccountReadHandler _sut = new();
+
+    private static Account MakeAccount(long id) => new()
+    {
+        Id = new AccountId(id),
+        Username = "u",
+        Email = "u@t",
+        Salt = new byte[] { 1 },
+        Verifier = new byte[] { 2 },
+        JoinDate = DateTime.UtcNow,
+    };
+
+    private static ClaimsPrincipal User(long accountId, params string[] roles)
+    {
+        var claims = new List<Claim> { new(ClaimTypes.NameIdentifier, accountId.ToString()) };
+        claims.AddRange(roles.Select(r => new Claim(ClaimTypes.Role, r)));
+        return new(new ClaimsIdentity(claims, "test", ClaimTypes.NameIdentifier, ClaimTypes.Role));
+    }
+
+    private async Task<bool> Run(ClaimsPrincipal user, Account resource)
+    {
+        var req = new ReadRequirement();
+        var ctx = new AuthorizationHandlerContext(new[] { req }, user, resource);
+        await _sut.HandleAsync(ctx);
+        return ctx.HasSucceeded;
+    }
+
+    [Fact]
+    public async Task Succeed_WhenSelf() =>
+        Assert.True(await Run(User(7, AvalonRoles.Player), MakeAccount(7)));
+
+    [Fact]
+    public async Task Succeed_WhenGameMaster() =>
+        Assert.True(await Run(User(99, AvalonRoles.GameMaster), MakeAccount(7)));
+
+    [Fact]
+    public async Task Fail_WhenPlayerNotSelf() =>
+        Assert.False(await Run(User(99, AvalonRoles.Player), MakeAccount(7)));
+}

--- a/tests/Avalon.Api.UnitTests/Authorization/AccountWriteHandlerShould.cs
+++ b/tests/Avalon.Api.UnitTests/Authorization/AccountWriteHandlerShould.cs
@@ -1,0 +1,55 @@
+using System.Security.Claims;
+using Avalon.Api.Authentication;
+using Avalon.Api.Authorization;
+using Avalon.Common.ValueObjects;
+using Avalon.Domain.Auth;
+using Microsoft.AspNetCore.Authorization;
+using Xunit;
+
+namespace Avalon.Api.UnitTests.Authorization;
+
+public class AccountWriteHandlerShould
+{
+    private readonly AccountWriteHandler _sut = new();
+
+    private static Account MakeAccount(long id) => new()
+    {
+        Id = new AccountId(id),
+        Username = "u",
+        Email = "u@t",
+        Salt = new byte[] { 1 },
+        Verifier = new byte[] { 2 },
+        JoinDate = DateTime.UtcNow,
+    };
+
+    private static ClaimsPrincipal User(long accountId, params string[] roles)
+    {
+        var claims = new List<Claim> { new(ClaimTypes.NameIdentifier, accountId.ToString()) };
+        claims.AddRange(roles.Select(r => new Claim(ClaimTypes.Role, r)));
+        return new(new ClaimsIdentity(claims, "test", ClaimTypes.NameIdentifier, ClaimTypes.Role));
+    }
+
+    private async Task<bool> Run(ClaimsPrincipal user, Account resource)
+    {
+        var req = new WriteRequirement();
+        var ctx = new AuthorizationHandlerContext(new[] { req }, user, resource);
+        await _sut.HandleAsync(ctx);
+        return ctx.HasSucceeded;
+    }
+
+    [Fact]
+    public async Task Succeed_WhenSelf() =>
+        Assert.True(await Run(User(7, AvalonRoles.Player), MakeAccount(7)));
+
+    [Fact]
+    public async Task Succeed_WhenAdmin() =>
+        Assert.True(await Run(User(99, AvalonRoles.Admin), MakeAccount(7)));
+
+    [Fact]
+    public async Task Fail_WhenGameMasterNotSelf() =>
+        Assert.False(await Run(User(99, AvalonRoles.GameMaster), MakeAccount(7)));
+
+    [Fact]
+    public async Task Fail_WhenPlayerNotSelf() =>
+        Assert.False(await Run(User(99, AvalonRoles.Player), MakeAccount(7)));
+}

--- a/tests/Avalon.Api.UnitTests/Authorization/CharacterReadHandlerShould.cs
+++ b/tests/Avalon.Api.UnitTests/Authorization/CharacterReadHandlerShould.cs
@@ -1,0 +1,65 @@
+using System.Security.Claims;
+using Avalon.Api.Authentication;
+using Avalon.Api.Authorization;
+using Avalon.Common.ValueObjects;
+using Avalon.Domain.Characters;
+using Microsoft.AspNetCore.Authorization;
+using Xunit;
+
+namespace Avalon.Api.UnitTests.Authorization;
+
+public class CharacterReadHandlerShould
+{
+    private readonly CharacterReadHandler _sut = new();
+
+    private static Character MakeCharacter(long accountId) => new()
+    {
+        Id = new CharacterId(1),
+        AccountId = new AccountId(accountId),
+        Name = "c",
+        CreationDate = DateTime.UtcNow,
+    };
+
+    private static ClaimsPrincipal User(long accountId, params string[] roles)
+    {
+        var claims = new List<Claim> { new(ClaimTypes.NameIdentifier, accountId.ToString()) };
+        claims.AddRange(roles.Select(r => new Claim(ClaimTypes.Role, r)));
+        return new(new ClaimsIdentity(claims, "test", ClaimTypes.NameIdentifier, ClaimTypes.Role));
+    }
+
+    private async Task<bool> Run(ClaimsPrincipal user, Character resource)
+    {
+        var req = new ReadRequirement();
+        var ctx = new AuthorizationHandlerContext(new[] { req }, user, resource);
+        await _sut.HandleAsync(ctx);
+        return ctx.HasSucceeded;
+    }
+
+    [Fact]
+    public async Task Succeed_WhenCallerIsOwner()
+    {
+        var c = MakeCharacter(accountId: 7);
+        Assert.True(await Run(User(7, AvalonRoles.Player), c));
+    }
+
+    [Fact]
+    public async Task Succeed_WhenCallerIsGameMaster()
+    {
+        var c = MakeCharacter(accountId: 7);
+        Assert.True(await Run(User(99, AvalonRoles.GameMaster), c));
+    }
+
+    [Fact]
+    public async Task Succeed_WhenCallerIsAdmin()
+    {
+        var c = MakeCharacter(accountId: 7);
+        Assert.True(await Run(User(99, AvalonRoles.Admin), c));
+    }
+
+    [Fact]
+    public async Task Fail_WhenCallerIsPlayerAndNotOwner()
+    {
+        var c = MakeCharacter(accountId: 7);
+        Assert.False(await Run(User(99, AvalonRoles.Player), c));
+    }
+}

--- a/tests/Avalon.Api.UnitTests/Authorization/CharacterWriteHandlerShould.cs
+++ b/tests/Avalon.Api.UnitTests/Authorization/CharacterWriteHandlerShould.cs
@@ -1,0 +1,49 @@
+using System.Security.Claims;
+using Avalon.Api.Authentication;
+using Avalon.Api.Authorization;
+using Avalon.Common.ValueObjects;
+using Avalon.Domain.Characters;
+using Microsoft.AspNetCore.Authorization;
+using Xunit;
+
+namespace Avalon.Api.UnitTests.Authorization;
+
+public class CharacterWriteHandlerShould
+{
+    private readonly CharacterWriteHandler _sut = new();
+
+    private static Character MakeCharacter(long accountId) => new()
+    {
+        Id = new CharacterId(1),
+        AccountId = new AccountId(accountId),
+        Name = "c",
+        CreationDate = DateTime.UtcNow,
+    };
+
+    private static ClaimsPrincipal User(long accountId, params string[] roles)
+    {
+        var claims = new List<Claim> { new(ClaimTypes.NameIdentifier, accountId.ToString()) };
+        claims.AddRange(roles.Select(r => new Claim(ClaimTypes.Role, r)));
+        return new(new ClaimsIdentity(claims, "test", ClaimTypes.NameIdentifier, ClaimTypes.Role));
+    }
+
+    private async Task<bool> Run(ClaimsPrincipal user, Character resource)
+    {
+        var req = new WriteRequirement();
+        var ctx = new AuthorizationHandlerContext(new[] { req }, user, resource);
+        await _sut.HandleAsync(ctx);
+        return ctx.HasSucceeded;
+    }
+
+    [Fact] public async Task Succeed_WhenCallerIsOwner() =>
+        Assert.True(await Run(User(7, AvalonRoles.Player), MakeCharacter(7)));
+
+    [Fact] public async Task Succeed_WhenCallerIsAdmin() =>
+        Assert.True(await Run(User(99, AvalonRoles.Admin), MakeCharacter(7)));
+
+    [Fact] public async Task Fail_WhenCallerIsGameMasterAndNotOwner() =>
+        Assert.False(await Run(User(99, AvalonRoles.GameMaster), MakeCharacter(7)));
+
+    [Fact] public async Task Fail_WhenCallerIsPlayerAndNotOwner() =>
+        Assert.False(await Run(User(99, AvalonRoles.Player), MakeCharacter(7)));
+}

--- a/tests/Avalon.Api.UnitTests/Controllers/AccountControllerShould.cs
+++ b/tests/Avalon.Api.UnitTests/Controllers/AccountControllerShould.cs
@@ -86,4 +86,19 @@ public class AccountControllerShould
 
         Assert.IsType<NotFoundResult>(result);
     }
+
+    [Fact]
+    public async Task FindById_Returns403_WhenAuthzFailsAndCallerIsGameMaster()
+    {
+        var user = User(99, AvalonRoles.GameMaster);
+        var account = MakeAccount(7);
+        _accountService.FindByIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>()).Returns(account);
+        _authz.AuthorizeAsync(user, account, Arg.Any<IEnumerable<IAuthorizationRequirement>>())
+              .Returns(AuthorizationResult.Failed());
+
+        var sut = MakeSut(user);
+        var result = await sut.FindById(7, CancellationToken.None);
+
+        Assert.IsType<ForbidResult>(result);
+    }
 }

--- a/tests/Avalon.Api.UnitTests/Controllers/AccountControllerShould.cs
+++ b/tests/Avalon.Api.UnitTests/Controllers/AccountControllerShould.cs
@@ -1,0 +1,89 @@
+using System.Security.Claims;
+using Avalon.Api.Authentication;
+using Avalon.Api.Controllers;
+using Avalon.Api.Services;
+using Avalon.Common.ValueObjects;
+using Avalon.Domain.Auth;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using Xunit;
+
+namespace Avalon.Api.UnitTests.Controllers;
+
+public class AccountControllerShould
+{
+    private readonly IAccountService _accountService = Substitute.For<IAccountService>();
+    private readonly IAuthorizationService _authz = Substitute.For<IAuthorizationService>();
+    private readonly IAuthContext _authContext = Substitute.For<IAuthContext>();
+
+    private AccountController MakeSut(ClaimsPrincipal user) =>
+        new(_accountService, _authContext, _authz)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext { User = user }
+            }
+        };
+
+    private static ClaimsPrincipal User(long accountId, params string[] roles)
+    {
+        var claims = new List<Claim> { new(ClaimTypes.NameIdentifier, accountId.ToString()) };
+        claims.AddRange(roles.Select(r => new Claim(ClaimTypes.Role, r)));
+        return new(new ClaimsIdentity(claims, "test", ClaimTypes.NameIdentifier, ClaimTypes.Role));
+    }
+
+    private static Account MakeAccount(long id) => new()
+    {
+        Id = new AccountId(id),
+        Username = "user",
+        Salt = new byte[] { 0x1 },
+        Verifier = new byte[] { 0x2 },
+        Email = "u@example.com",
+        JoinDate = DateTime.UtcNow,
+    };
+
+    [Fact]
+    public async Task FindById_Returns200_WhenCallerIsSelf()
+    {
+        var user = User(7, AvalonRoles.Player);
+        var account = MakeAccount(7);
+        _accountService.FindByIdAsync(new AccountId(7), Arg.Any<CancellationToken>()).Returns(account);
+        _authz.AuthorizeAsync(user, account, Arg.Any<IEnumerable<IAuthorizationRequirement>>())
+              .Returns(AuthorizationResult.Success());
+
+        var sut = MakeSut(user);
+        var result = await sut.FindById(7, CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task FindById_Returns404_WhenPlayerAsksForOthersAccount()
+    {
+        var user = User(7, AvalonRoles.Player);
+        var account = MakeAccount(99);
+        _accountService.FindByIdAsync(new AccountId(99), Arg.Any<CancellationToken>()).Returns(account);
+        _authz.AuthorizeAsync(user, account, Arg.Any<IEnumerable<IAuthorizationRequirement>>())
+              .Returns(AuthorizationResult.Failed());
+
+        var sut = MakeSut(user);
+        var result = await sut.FindById(99, CancellationToken.None);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task FindById_Returns404_WhenAccountMissing()
+    {
+        var user = User(7, AvalonRoles.Player);
+        _accountService.FindByIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
+            .Returns((Account?)null);
+
+        var sut = MakeSut(user);
+        var result = await sut.FindById(123, CancellationToken.None);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+}

--- a/tests/Avalon.Api.UnitTests/Controllers/CharacterControllerShould.cs
+++ b/tests/Avalon.Api.UnitTests/Controllers/CharacterControllerShould.cs
@@ -1,0 +1,88 @@
+using System.Security.Claims;
+using Avalon.Api.Authentication;
+using Avalon.Api.Authorization;
+using Avalon.Api.Controllers;
+using Avalon.Api.Services;
+using Avalon.Common.ValueObjects;
+using Avalon.Domain.Characters;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using Xunit;
+
+namespace Avalon.Api.UnitTests.Controllers;
+
+public class CharacterControllerShould
+{
+    private readonly ICharacterService _service = Substitute.For<ICharacterService>();
+    private readonly IAuthorizationService _authz = Substitute.For<IAuthorizationService>();
+    private readonly IAuthContext _authContext = Substitute.For<IAuthContext>();
+
+    private CharacterController MakeSut(ClaimsPrincipal user) =>
+        new(_authContext, _service, _authz)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext { User = user }
+            }
+        };
+
+    private static ClaimsPrincipal User(long accountId, params string[] roles)
+    {
+        var claims = new List<Claim> { new(ClaimTypes.NameIdentifier, accountId.ToString()) };
+        claims.AddRange(roles.Select(r => new Claim(ClaimTypes.Role, r)));
+        return new(new ClaimsIdentity(claims, "test", ClaimTypes.NameIdentifier, ClaimTypes.Role));
+    }
+
+    private static Character MakeChar(long accountId) => new()
+    {
+        Id = new CharacterId(42),
+        AccountId = new AccountId(accountId),
+        Name = "c",
+        CreationDate = DateTime.UtcNow,
+    };
+
+    [Fact]
+    public async Task GetById_Returns200_WhenAuthzSucceeds()
+    {
+        var user = User(7, AvalonRoles.Player);
+        var ch = MakeChar(7);
+        _service.GetCharacterByIdAsync(new CharacterId(42), Arg.Any<CancellationToken>()).Returns(ch);
+        _authz.AuthorizeAsync(user, ch, Arg.Any<IEnumerable<IAuthorizationRequirement>>())
+              .Returns(AuthorizationResult.Success());
+
+        var sut = MakeSut(user);
+        var result = await sut.GetById(42, CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task GetById_Returns404_WhenEntityMissing()
+    {
+        var user = User(7, AvalonRoles.Player);
+        _service.GetCharacterByIdAsync(Arg.Any<CharacterId>(), Arg.Any<CancellationToken>())
+            .Returns((Character?)null);
+
+        var sut = MakeSut(user);
+        var result = await sut.GetById(42, CancellationToken.None);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task GetById_Returns404_WhenAuthzFailsAndCallerIsPlayer()
+    {
+        var user = User(7, AvalonRoles.Player);
+        var ch = MakeChar(99);
+        _service.GetCharacterByIdAsync(Arg.Any<CharacterId>(), Arg.Any<CancellationToken>()).Returns(ch);
+        _authz.AuthorizeAsync(user, ch, Arg.Any<IEnumerable<IAuthorizationRequirement>>())
+              .Returns(AuthorizationResult.Failed());
+
+        var sut = MakeSut(user);
+        var result = await sut.GetById(42, CancellationToken.None);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+}

--- a/tests/Avalon.Api.UnitTests/Controllers/CharacterControllerShould.cs
+++ b/tests/Avalon.Api.UnitTests/Controllers/CharacterControllerShould.cs
@@ -85,4 +85,19 @@ public class CharacterControllerShould
 
         Assert.IsType<NotFoundResult>(result);
     }
+
+    [Fact]
+    public async Task GetById_Returns403_WhenAuthzFailsAndCallerIsGameMaster()
+    {
+        var user = User(99, AvalonRoles.GameMaster);
+        var ch = MakeChar(7);
+        _service.GetCharacterByIdAsync(Arg.Any<CharacterId>(), Arg.Any<CancellationToken>()).Returns(ch);
+        _authz.AuthorizeAsync(user, ch, Arg.Any<IEnumerable<IAuthorizationRequirement>>())
+              .Returns(AuthorizationResult.Failed());
+
+        var sut = MakeSut(user);
+        var result = await sut.GetById(42, CancellationToken.None);
+
+        Assert.IsType<ForbidResult>(result);
+    }
 }

--- a/tests/Avalon.Server.Auth.UnitTests/Handlers/CWorldListHandlerShould.cs
+++ b/tests/Avalon.Server.Auth.UnitTests/Handlers/CWorldListHandlerShould.cs
@@ -78,7 +78,7 @@ public class CWorldListHandlerShould
         _accountRepository.FindByIdAsync(account.Id).Returns(account);
 
         var playerWorld = MakeWorld(1, AccountAccessLevel.Player);
-        var adminWorld = MakeWorld(2, AccountAccessLevel.Administrator);
+        var adminWorld = MakeWorld(2, AccountAccessLevel.Admin);
         _worldRepository.FindAllAsync().Returns(new List<AvalonWorld> { playerWorld, adminWorld });
 
         var ctx = new AuthPacketContext<CWorldListPacket>
@@ -96,12 +96,12 @@ public class CWorldListHandlerShould
     [Fact]
     public async Task SendAllWorlds_WhenAccountIsAdministrator()
     {
-        var account = MakeAccount(level: AccountAccessLevel.Administrator);
+        var account = MakeAccount(level: AccountAccessLevel.Admin);
         _connection.AccountId.Returns(account.Id);
         _accountRepository.FindByIdAsync(account.Id).Returns(account);
 
         var playerWorld = MakeWorld(1, AccountAccessLevel.Player);
-        var adminWorld = MakeWorld(2, AccountAccessLevel.Administrator);
+        var adminWorld = MakeWorld(2, AccountAccessLevel.Admin);
         _worldRepository.FindAllAsync().Returns(new List<AvalonWorld> { playerWorld, adminWorld });
 
         var ctx = new AuthPacketContext<CWorldListPacket>

--- a/tests/Avalon.Server.Auth.UnitTests/Handlers/CWorldSelectHandlerShould.cs
+++ b/tests/Avalon.Server.Auth.UnitTests/Handlers/CWorldSelectHandlerShould.cs
@@ -101,7 +101,7 @@ public class CWorldSelectHandlerShould
         var account = MakeAccount(level: AccountAccessLevel.Player);
         _connection.AccountId.Returns(account.Id);
         _accountRepository.FindByIdAsync(account.Id).Returns(account);
-        var world = MakeWorld(req: AccountAccessLevel.Administrator);
+        var world = MakeWorld(req: AccountAccessLevel.Admin);
         _worldRepository.FindByIdAsync(Arg.Any<WorldId>()).Returns(world);
 
         var ctx = new AuthPacketContext<CWorldSelectPacket>


### PR DESCRIPTION
## Summary

- Introduces resource-based authorization primitives (`ReadRequirement`, `WriteRequirement`) and per-resource `AuthorizationHandler<TReq, TResource>` pairs for `Character` and `Account`.
- Fixes the pre-existing role-claim/policy mismatch: `AccountAccessLevel` renumbered so names match `AvalonRoles.*` constants (`Player=1, GameMaster=2, Admin=4, Console=8, Tournament=16, PTR=32`). Previously broken: policies `Player`, `Admin`, `Console` were unreachable because the enum used `Administrator` (not `Admin`) and `Player=0` which JwtUtils never emits.
- EF migration bitwise-remaps stored values on `Accounts.AccessLevel` and `Worlds.AccessLevelRequired`.
- Removes a duplicate `AccountAccessLevel` enum in `Avalon.Api.Contract` that was silently corrupting `/account/{id}` responses via cross-enum numeric cast.
- Closes ownership gap on `GET /character/{id}` — any authenticated caller previously could fetch any character. Now: owner OR GameMaster+.
- Switches `GET /account/{id}` from GM-only to self-or-GM+ via `ReadRequirement`.
- Existence-hiding: non-role, non-owner Player callers get `404` (not `403`) to avoid leaking existence of other users' resources.
- Adds `ClaimsPrincipal.AccountId()` and `HasRoleAtLeast(string)` helpers — the latter walks the role ladder since JWT emits one `GroupSid` claim per flag bit (no implicit hierarchy).

## Details

- `CharacterService` / `CharacterRepository` now accept `CancellationToken` and return nullable on single-entity lookup; service no longer enforces ownership (moved to handler).
- `BaseController.NotFoundOrForbid()` centralises the existence-hiding decision.

## Test plan

- [x] 495 → 497 unit tests passing (30+ new across JwtUtils, ClaimsPrincipalExtensions, the 4 resource handlers, 2 controllers).
- [x] Build clean.
- [ ] Smoke test against local Postgres: migration applies cleanly, existing seed admin flows still work.
- [ ] Verify policies `Player`, `Admin`, `Console` actually accept their respective role claims after migration.

## Notes

Resource authz pattern established here is reused by PRs #A2 (controller expansion) and #B (PAT tokens).