### PR TITLE
feat(api): controller expansion — Character/Account writes, World, templates

### DIFF
--- a/src/Server/Avalon.Api/Contract/AccountEmailChangeRequest.cs
+++ b/src/Server/Avalon.Api/Contract/AccountEmailChangeRequest.cs
@@ -1,0 +1,8 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Avalon.Api.Contract;
+
+public sealed class AccountEmailChangeRequest
+{
+    [Required, EmailAddress] public string NewEmail { get; set; } = "";
+}

--- a/src/Server/Avalon.Api/Contract/AccountEmailConfirmRequest.cs
+++ b/src/Server/Avalon.Api/Contract/AccountEmailConfirmRequest.cs
@@ -1,0 +1,8 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Avalon.Api.Contract;
+
+public sealed class AccountEmailConfirmRequest
+{
+    [Required] public string Token { get; set; } = "";
+}

--- a/src/Server/Avalon.Api/Contract/AccountPasswordChangeRequest.cs
+++ b/src/Server/Avalon.Api/Contract/AccountPasswordChangeRequest.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Avalon.Api.Contract;
+
+public sealed class AccountPasswordChangeRequest
+{
+    [Required] public string CurrentPassword { get; set; } = "";
+    [Required, MinLength(8)] public string NewPassword { get; set; } = "";
+}

--- a/src/Server/Avalon.Api/Contract/AccountRolesPatchRequest.cs
+++ b/src/Server/Avalon.Api/Contract/AccountRolesPatchRequest.cs
@@ -1,0 +1,8 @@
+using Avalon.Domain.Auth;
+
+namespace Avalon.Api.Contract;
+
+public sealed class AccountRolesPatchRequest
+{
+    public AccountAccessLevel Roles { get; set; }
+}

--- a/src/Server/Avalon.Api/Contract/AccountStatusPatchRequest.cs
+++ b/src/Server/Avalon.Api/Contract/AccountStatusPatchRequest.cs
@@ -1,0 +1,10 @@
+using System.ComponentModel.DataAnnotations;
+using Avalon.Domain.Auth;
+
+namespace Avalon.Api.Contract;
+
+public sealed class AccountStatusPatchRequest
+{
+    [Required] public AccountStatus State { get; set; }
+    public string? Reason { get; set; }
+}

--- a/src/Server/Avalon.Api/Contract/CharacterInventoryDto.cs
+++ b/src/Server/Avalon.Api/Contract/CharacterInventoryDto.cs
@@ -1,0 +1,16 @@
+using Avalon.World.Public.Enums;
+
+namespace Avalon.Api.Contract;
+
+public sealed class CharacterInventoryDto
+{
+    public uint CharacterId { get; set; }
+    public List<CharacterInventoryItemDto> Items { get; set; } = new();
+}
+
+public sealed class CharacterInventoryItemDto
+{
+    public Guid ItemId { get; set; }
+    public InventoryType Container { get; set; }
+    public ushort Slot { get; set; }
+}

--- a/src/Server/Avalon.Api/Contract/CharacterPaginateFilters.cs
+++ b/src/Server/Avalon.Api/Contract/CharacterPaginateFilters.cs
@@ -1,0 +1,51 @@
+// Licensed to the Avalon MMORPG Game under one or more agreements.
+// Avalon MMORPG Game licenses this file to you under the MIT license.
+
+using System.Linq.Expressions;
+using Avalon.Common.ValueObjects;
+using Avalon.Database;
+using Avalon.Domain.Characters;
+using LinqKit;
+using Microsoft.EntityFrameworkCore;
+
+namespace Avalon.Api.Contract;
+
+public class CharacterPaginateFilters : EntityPaginateFilter<Character>
+{
+    public string? NameLike { get; set; }
+    public long? AccountId { get; set; }
+
+    public override Expression<Func<Character, bool>> GetFilter()
+    {
+        var predicate = PredicateBuilder.New<Character>(true);
+
+        if (AccountId is { } aid)
+        {
+            var accountId = new AccountId(aid);
+            predicate = predicate.And(c => c.AccountId == accountId);
+        }
+
+        if (!string.IsNullOrEmpty(NameLike))
+        {
+            var pattern = $"%{NameLike}%";
+            predicate = predicate.And(c => EF.Functions.ILike(c.Name, pattern));
+        }
+
+        return predicate;
+    }
+
+    public override Expression<Func<Character, object>>? GetSortKeySelector()
+    {
+        if (string.IsNullOrEmpty(SortBy))
+            return c => c.Name;
+
+        return SortBy.ToLower() switch
+        {
+            "name" => c => c.Name,
+            "level" => c => c.Level,
+            "experience" => c => c.Experience,
+            "creationdate" => c => c.CreationDate,
+            _ => null
+        };
+    }
+}

--- a/src/Server/Avalon.Api/Contract/CharacterPatchDto.cs
+++ b/src/Server/Avalon.Api/Contract/CharacterPatchDto.cs
@@ -1,0 +1,14 @@
+namespace Avalon.Api.Contract;
+
+public sealed class CharacterPatchDto
+{
+    // Cosmetic (any owner or Admin+)
+    public string? Name { get; set; }
+
+    // Admin+ only
+    public ushort? Level { get; set; }
+    public ulong?  Experience { get; set; }
+    public int?    Health { get; set; }
+    public int?    Power1 { get; set; }
+    public int?    Power2 { get; set; }
+}

--- a/src/Server/Avalon.Api/Contract/CreateWorldRequest.cs
+++ b/src/Server/Avalon.Api/Contract/CreateWorldRequest.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel.DataAnnotations;
+using Avalon.Domain.Auth;
+
+namespace Avalon.Api.Contract;
+
+public sealed class CreateWorldRequest
+{
+    [Required] public string Name { get; set; } = "";
+    [Required] public string Host { get; set; } = "";
+    [Required] public int Port { get; set; }
+    [Required] public string MinVersion { get; set; } = "";
+    [Required] public string Version { get; set; } = "";
+    public WorldType Type { get; set; } = WorldType.PvE;
+    public AccountAccessLevel AccessLevelRequired { get; set; } = AccountAccessLevel.Player;
+    public WorldStatus Status { get; set; } = WorldStatus.Offline;
+}

--- a/src/Server/Avalon.Api/Contract/CreatureTemplateDto.cs
+++ b/src/Server/Avalon.Api/Contract/CreatureTemplateDto.cs
@@ -1,0 +1,43 @@
+using Avalon.World.Public.Enums;
+
+namespace Avalon.Api.Contract;
+
+public sealed class CreatureTemplateDto
+{
+    public ulong Id { get; set; }
+    public string Name { get; set; } = "";
+    public string SubName { get; set; } = "";
+    public string IconName { get; set; } = "";
+    public short MinLevel { get; set; }
+    public short MaxLevel { get; set; }
+    public float SpeedWalk { get; set; }
+    public float SpeedRun { get; set; }
+    public float SpeedSwim { get; set; }
+    public short Rank { get; set; }
+    public CreatureFamily Family { get; set; }
+    public CreatureType Type { get; set; }
+    public int LootId { get; set; }
+    public int MinGold { get; set; }
+    public int MaxGold { get; set; }
+    public string AIName { get; set; } = "";
+    public short MovementType { get; set; }
+    public float DetectionRange { get; set; }
+    public int MovementId { get; set; }
+    public string ScriptName { get; set; } = "";
+    public float HealthModifier { get; set; }
+    public float ManaModifier { get; set; }
+    public float ArmorModifier { get; set; }
+    public float ExperienceModifier { get; set; }
+    public short RegenHealth { get; set; }
+    public short DmgSchool { get; set; }
+    public float DamageModifier { get; set; }
+    public int BaseAttackTime { get; set; }
+    public int RangeAttackTime { get; set; }
+    public uint Experience { get; set; }
+
+    /// <summary>Seconds before the creature re-spawns after death.</summary>
+    public int RespawnTimerSecs { get; set; }
+
+    /// <summary>Seconds before the creature's corpse is removed.</summary>
+    public int BodyRemoveTimerSecs { get; set; }
+}

--- a/src/Server/Avalon.Api/Contract/CreatureTemplatePaginateFilters.cs
+++ b/src/Server/Avalon.Api/Contract/CreatureTemplatePaginateFilters.cs
@@ -1,0 +1,27 @@
+using System.Linq.Expressions;
+using Avalon.Database;
+using Avalon.Domain.World;
+using LinqKit;
+
+namespace Avalon.Api.Contract;
+
+public class CreatureTemplatePaginateFilters : EntityPaginateFilter<CreatureTemplate>
+{
+    public override Expression<Func<CreatureTemplate, bool>> GetFilter()
+    {
+        return PredicateBuilder.New<CreatureTemplate>(true);
+    }
+
+    public override Expression<Func<CreatureTemplate, object>>? GetSortKeySelector()
+    {
+        if (string.IsNullOrEmpty(SortBy))
+            return t => t.Id;
+
+        return SortBy.ToLower() switch
+        {
+            "name" => t => t.Name,
+            "id" => t => t.Id,
+            _ => null
+        };
+    }
+}

--- a/src/Server/Avalon.Api/Contract/ItemTemplateDto.cs
+++ b/src/Server/Avalon.Api/Contract/ItemTemplateDto.cs
@@ -1,0 +1,49 @@
+using Avalon.Domain.World;
+using WorldCharacterClass = Avalon.World.Public.Enums.CharacterClass;
+
+namespace Avalon.Api.Contract;
+
+public sealed class ItemTemplateDto
+{
+    public ulong Id { get; set; }
+    public string Name { get; set; } = "";
+    public ItemClass Class { get; set; }
+    public ItemSubClass SubClass { get; set; }
+    public ItemTemplateFlags Flags { get; set; }
+    public bool Stackable { get; set; }
+    public uint MaxStackSize { get; set; }
+    public uint DisplayId { get; set; }
+    public ItemRarity Rarity { get; set; }
+    public uint BuyPrice { get; set; }
+    public uint SellPrice { get; set; }
+    public ItemSlotType? Slot { get; set; }
+    public List<WorldCharacterClass> AllowedClasses { get; set; } = [];
+    public ushort? ItemPower { get; set; }
+    public ushort? RequiredLevel { get; set; }
+    public uint? DamageMin1 { get; set; }
+    public uint? DamageMax1 { get; set; }
+    public DamageType? DamageType1 { get; set; }
+    public uint? DamageMin2 { get; set; }
+    public uint? DamageMax2 { get; set; }
+    public DamageType? DamageType2 { get; set; }
+    public StatType? StatType1 { get; set; }
+    public uint? StatValue1 { get; set; }
+    public StatType? StatType2 { get; set; }
+    public uint? StatValue2 { get; set; }
+    public StatType? StatType3 { get; set; }
+    public uint? StatValue3 { get; set; }
+    public StatType? StatType4 { get; set; }
+    public uint? StatValue4 { get; set; }
+    public StatType? StatType5 { get; set; }
+    public uint? StatValue5 { get; set; }
+    public StatType? StatType6 { get; set; }
+    public uint? StatValue6 { get; set; }
+    public StatType? StatType7 { get; set; }
+    public uint? StatValue7 { get; set; }
+    public StatType? StatType8 { get; set; }
+    public uint? StatValue8 { get; set; }
+    public StatType? StatType9 { get; set; }
+    public uint? StatValue9 { get; set; }
+    public StatType? StatType10 { get; set; }
+    public uint? StatValue10 { get; set; }
+}

--- a/src/Server/Avalon.Api/Contract/ItemTemplatePaginateFilters.cs
+++ b/src/Server/Avalon.Api/Contract/ItemTemplatePaginateFilters.cs
@@ -1,0 +1,27 @@
+using System.Linq.Expressions;
+using Avalon.Database;
+using Avalon.Domain.World;
+using LinqKit;
+
+namespace Avalon.Api.Contract;
+
+public class ItemTemplatePaginateFilters : EntityPaginateFilter<ItemTemplate>
+{
+    public override Expression<Func<ItemTemplate, bool>> GetFilter()
+    {
+        return PredicateBuilder.New<ItemTemplate>(true);
+    }
+
+    public override Expression<Func<ItemTemplate, object>>? GetSortKeySelector()
+    {
+        if (string.IsNullOrEmpty(SortBy))
+            return t => t.Id;
+
+        return SortBy.ToLower() switch
+        {
+            "name" => t => t.Name,
+            "id" => t => t.Id,
+            _ => null
+        };
+    }
+}

--- a/src/Server/Avalon.Api/Contract/MapTemplateDto.cs
+++ b/src/Server/Avalon.Api/Contract/MapTemplateDto.cs
@@ -1,0 +1,33 @@
+using Avalon.World.Public.Enums;
+
+namespace Avalon.Api.Contract;
+
+public sealed class MapTemplateDto
+{
+    public ushort Id { get; set; }
+    public string Name { get; set; } = "";
+    public string Description { get; set; } = "";
+    public string Directory { get; set; } = "";
+
+    /// <summary>Whether this map is a shared Town hub or a private Normal instanced map.</summary>
+    public MapType MapType { get; set; }
+
+    public bool PvP { get; set; }
+    public ushort? MinLevel { get; set; }
+    public ushort? MaxLevel { get; set; }
+    public int AreaTableId { get; set; }
+    public int LoadingScreenId { get; set; }
+    public float? CorpseX { get; set; }
+    public float? CorpseY { get; set; }
+    public float? CorpseZ { get; set; }
+
+    /// <summary>Maximum number of players allowed per instance.</summary>
+    public ushort? MaxPlayers { get; set; }
+
+    public float DefaultSpawnX { get; set; }
+    public float DefaultSpawnY { get; set; }
+    public float DefaultSpawnZ { get; set; }
+
+    /// <summary>For Normal maps: the Town map ID players are returned to when they log out.</summary>
+    public ushort? ReturnMapId { get; set; }
+}

--- a/src/Server/Avalon.Api/Contract/MapTemplatePaginateFilters.cs
+++ b/src/Server/Avalon.Api/Contract/MapTemplatePaginateFilters.cs
@@ -1,0 +1,27 @@
+using System.Linq.Expressions;
+using Avalon.Database;
+using Avalon.Domain.World;
+using LinqKit;
+
+namespace Avalon.Api.Contract;
+
+public class MapTemplatePaginateFilters : EntityPaginateFilter<MapTemplate>
+{
+    public override Expression<Func<MapTemplate, bool>> GetFilter()
+    {
+        return PredicateBuilder.New<MapTemplate>(true);
+    }
+
+    public override Expression<Func<MapTemplate, object>>? GetSortKeySelector()
+    {
+        if (string.IsNullOrEmpty(SortBy))
+            return t => t.Id;
+
+        return SortBy.ToLower() switch
+        {
+            "name" => t => t.Name,
+            "id" => t => t.Id,
+            _ => null
+        };
+    }
+}

--- a/src/Server/Avalon.Api/Contract/SpellTemplateDto.cs
+++ b/src/Server/Avalon.Api/Contract/SpellTemplateDto.cs
@@ -1,0 +1,25 @@
+using Avalon.World.Public.Enums;
+using WorldCharacterClass = Avalon.World.Public.Enums.CharacterClass;
+
+namespace Avalon.Api.Contract;
+
+public sealed class SpellTemplateDto
+{
+    public uint Id { get; set; }
+    public string Name { get; set; } = "";
+
+    /// <summary>Cast time in milliseconds.</summary>
+    public uint CastTime { get; set; }
+
+    /// <summary>Cooldown in milliseconds.</summary>
+    public uint Cooldown { get; set; }
+
+    /// <summary>Cost in power points.</summary>
+    public uint Cost { get; set; }
+
+    public string SpellScript { get; set; } = "";
+    public SpellRange Range { get; set; }
+    public SpellEffect Effects { get; set; }
+    public uint EffectValue { get; set; }
+    public List<WorldCharacterClass> AllowedClasses { get; set; } = [];
+}

--- a/src/Server/Avalon.Api/Contract/SpellTemplatePaginateFilters.cs
+++ b/src/Server/Avalon.Api/Contract/SpellTemplatePaginateFilters.cs
@@ -1,0 +1,27 @@
+using System.Linq.Expressions;
+using Avalon.Database;
+using Avalon.Domain.World;
+using LinqKit;
+
+namespace Avalon.Api.Contract;
+
+public class SpellTemplatePaginateFilters : EntityPaginateFilter<SpellTemplate>
+{
+    public override Expression<Func<SpellTemplate, bool>> GetFilter()
+    {
+        return PredicateBuilder.New<SpellTemplate>(true);
+    }
+
+    public override Expression<Func<SpellTemplate, object>>? GetSortKeySelector()
+    {
+        if (string.IsNullOrEmpty(SortBy))
+            return t => t.Id;
+
+        return SortBy.ToLower() switch
+        {
+            "name" => t => t.Name,
+            "id" => t => t.Id,
+            _ => null
+        };
+    }
+}

--- a/src/Server/Avalon.Api/Contract/UpdateWorldRequest.cs
+++ b/src/Server/Avalon.Api/Contract/UpdateWorldRequest.cs
@@ -1,0 +1,15 @@
+using Avalon.Domain.Auth;
+
+namespace Avalon.Api.Contract;
+
+public sealed class UpdateWorldRequest
+{
+    public string? Name { get; set; }
+    public string? Host { get; set; }
+    public int? Port { get; set; }
+    public string? MinVersion { get; set; }
+    public string? Version { get; set; }
+    public WorldType? Type { get; set; }
+    public AccountAccessLevel? AccessLevelRequired { get; set; }
+    public WorldStatus? Status { get; set; }
+}

--- a/src/Server/Avalon.Api/Contract/WorldDto.cs
+++ b/src/Server/Avalon.Api/Contract/WorldDto.cs
@@ -1,0 +1,19 @@
+using Avalon.Domain.Auth;
+
+namespace Avalon.Api.Contract;
+
+public sealed class WorldDto
+{
+    public ushort Id { get; set; }
+    public string Name { get; set; } = "";
+    public WorldType Type { get; set; }
+    public AccountAccessLevel AccessLevelRequired { get; set; }
+    public string Host { get; set; } = "";
+    public int Port { get; set; }
+    public string MinVersion { get; set; } = "";
+    public string Version { get; set; } = "";
+    public WorldStatus Status { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public int OnlineCount { get; set; }
+}

--- a/src/Server/Avalon.Api/Contract/WorldPaginateFilters.cs
+++ b/src/Server/Avalon.Api/Contract/WorldPaginateFilters.cs
@@ -1,0 +1,27 @@
+using System.Linq.Expressions;
+using Avalon.Database;
+using LinqKit;
+using WorldEntity = Avalon.Domain.Auth.World;
+
+namespace Avalon.Api.Contract;
+
+public class WorldPaginateFilters : EntityPaginateFilter<WorldEntity>
+{
+    public override Expression<Func<WorldEntity, bool>> GetFilter()
+    {
+        return PredicateBuilder.New<WorldEntity>(true);
+    }
+
+    public override Expression<Func<WorldEntity, object>>? GetSortKeySelector()
+    {
+        if (string.IsNullOrEmpty(SortBy))
+            return w => w.Name;
+
+        return SortBy.ToLower() switch
+        {
+            "name" => w => w.Name,
+            "status" => w => w.Status,
+            _ => null
+        };
+    }
+}

--- a/src/Server/Avalon.Api/Controllers/AccountController.cs
+++ b/src/Server/Avalon.Api/Controllers/AccountController.cs
@@ -74,4 +74,14 @@ public class AccountController : BaseController
         var language = Request.Headers.AcceptLanguage.ToString();
         return await _accountService.Register(model, userAgent, IpAddress, CancellationToken);
     }
+
+    [HttpPost("password")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> ChangePassword([FromBody] AccountPasswordChangeRequest request, CancellationToken ct)
+    {
+        var accountId = User.AccountId();
+        await _accountService.ChangePasswordAsync(accountId, request.CurrentPassword, request.NewPassword, ct);
+        return NoContent();
+    }
 }

--- a/src/Server/Avalon.Api/Controllers/AccountController.cs
+++ b/src/Server/Avalon.Api/Controllers/AccountController.cs
@@ -115,4 +115,16 @@ public class AccountController : BaseController
         await _accountService.UpdateStatusAsync(new AccountId(id), req.State, req.Reason, ct);
         return NoContent();
     }
+
+    [HttpPatch("{id:long}/roles")]
+    [Authorize(Policy = AvalonRoles.Console)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    public async Task<IActionResult> UpdateRoles(
+        [FromRoute] long id,
+        [FromBody] AccountRolesPatchRequest req,
+        CancellationToken ct)
+    {
+        await _accountService.UpdateRolesAsync(new AccountId(id), req.Roles, ct);
+        return NoContent();
+    }
 }

--- a/src/Server/Avalon.Api/Controllers/AccountController.cs
+++ b/src/Server/Avalon.Api/Controllers/AccountController.cs
@@ -84,4 +84,22 @@ public class AccountController : BaseController
         await _accountService.ChangePasswordAsync(accountId, request.CurrentPassword, request.NewPassword, ct);
         return NoContent();
     }
+
+    [HttpPost("email/change")]
+    [ProducesResponseType(StatusCodes.Status202Accepted)]
+    public async Task<IActionResult> InitiateEmailChange([FromBody] AccountEmailChangeRequest req, CancellationToken ct)
+    {
+        await _accountService.InitiateEmailChangeAsync(User.AccountId(), req.NewEmail, ct);
+        return Accepted();
+    }
+
+    [AllowAnonymous]
+    [HttpPost("email/confirm")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> ConfirmEmailChange([FromBody] AccountEmailConfirmRequest req, CancellationToken ct)
+    {
+        await _accountService.ConfirmEmailChangeAsync(req.Token, ct);
+        return NoContent();
+    }
 }

--- a/src/Server/Avalon.Api/Controllers/AccountController.cs
+++ b/src/Server/Avalon.Api/Controllers/AccountController.cs
@@ -102,4 +102,17 @@ public class AccountController : BaseController
         await _accountService.ConfirmEmailChangeAsync(req.Token, ct);
         return NoContent();
     }
+
+    [HttpPatch("{id:long}/status")]
+    [Authorize(Policy = AvalonRoles.Admin)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> UpdateStatus(
+        [FromRoute] long id,
+        [FromBody] AccountStatusPatchRequest req,
+        CancellationToken ct)
+    {
+        await _accountService.UpdateStatusAsync(new AccountId(id), req.State, req.Reason, ct);
+        return NoContent();
+    }
 }

--- a/src/Server/Avalon.Api/Controllers/CharacterController.cs
+++ b/src/Server/Avalon.Api/Controllers/CharacterController.cs
@@ -49,4 +49,24 @@ public class CharacterController : BaseController
 
         return Ok(character.ToDto());
     }
+
+    [HttpPatch("{id}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> Patch([FromRoute] uint id, [FromBody] CharacterPatchDto dto, CancellationToken ct)
+    {
+        var character = await _service.GetCharacterByIdAsync(new CharacterId(id), ct);
+        if (character is null) return NotFound();
+
+        var authz = await _authz.AuthorizeAsync(User, character, new WriteRequirement());
+        if (!authz.Succeeded) return NotFoundOrForbid();
+
+        if (User.HasRoleAtLeast(AvalonRoles.Admin))
+            await _service.UpdateAnyAsync(character, dto, ct);
+        else
+            await _service.UpdateCosmeticAsync(character, dto.Name, ct);
+
+        return NoContent();
+    }
 }

--- a/src/Server/Avalon.Api/Controllers/CharacterController.cs
+++ b/src/Server/Avalon.Api/Controllers/CharacterController.cs
@@ -50,6 +50,22 @@ public class CharacterController : BaseController
         return Ok(character.ToDto());
     }
 
+    [HttpGet("{id}/inventory", Name = "GetCharacterInventory")]
+    [ProducesResponseType(typeof(CharacterInventoryDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> GetInventory([FromRoute] uint id, CancellationToken ct)
+    {
+        var character = await _service.GetCharacterByIdAsync(new CharacterId(id), ct);
+        if (character is null) return NotFound();
+
+        var authz = await _authz.AuthorizeAsync(User, character, new ReadRequirement());
+        if (!authz.Succeeded) return NotFoundOrForbid();
+
+        var inventory = await _service.GetInventoryAsync(new CharacterId(id), ct);
+        return Ok(inventory);
+    }
+
     [HttpPatch("{id}")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]

--- a/src/Server/Avalon.Api/Controllers/CharacterController.cs
+++ b/src/Server/Avalon.Api/Controllers/CharacterController.cs
@@ -4,6 +4,8 @@ using Avalon.Api.Contract;
 using Avalon.Api.Contract.Mappers;
 using Avalon.Api.Services;
 using Avalon.Common.ValueObjects;
+using Avalon.Database;
+using Avalon.Database.Extensions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
@@ -33,6 +35,15 @@ public class CharacterController : BaseController
 
         var characters = await _service.GetAllCharactersAsync(accountId, ct);
         return characters.Select(c => c.ToDto()).ToList();
+    }
+
+    [Authorize(Policy = AvalonRoles.GameMaster)]
+    [HttpGet("paginate", Name = "PaginateCharacters")]
+    [ProducesResponseType(typeof(PagedResult<CharacterDto>), 200)]
+    public async Task<PagedResult<CharacterDto>> Paginate([FromQuery] CharacterPaginateFilters filters, CancellationToken ct)
+    {
+        var page = await _service.PaginateAsync(filters, ct);
+        return page.MapTo(c => c.ToDto());
     }
 
     [HttpGet("{id}", Name = "GetCharacterById")]

--- a/src/Server/Avalon.Api/Controllers/CreatureTemplateController.cs
+++ b/src/Server/Avalon.Api/Controllers/CreatureTemplateController.cs
@@ -1,0 +1,86 @@
+using Avalon.Api.Authentication;
+using Avalon.Api.Contract;
+using Avalon.Common.ValueObjects;
+using Avalon.Database;
+using Avalon.Database.Extensions;
+using Avalon.Database.World.Repositories;
+using Avalon.Domain.World;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Avalon.Api.Controllers;
+
+[ApiController]
+[Authorize(Policy = AvalonRoles.Player)]
+[Route("creature-template")]
+public class CreatureTemplateController : BaseController
+{
+    private readonly ICreatureTemplateRepository _repository;
+
+    public CreatureTemplateController(ICreatureTemplateRepository repository)
+    {
+        _repository = repository;
+    }
+
+    [HttpGet(Name = "ListCreatureTemplates")]
+    [ProducesResponseType(typeof(PagedResult<CreatureTemplateDto>), StatusCodes.Status200OK)]
+    public async Task<PagedResult<CreatureTemplateDto>> List(
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 50,
+        CancellationToken ct = default)
+    {
+        var filter = new CreatureTemplatePaginateFilters
+        {
+            Page = page < 1 ? 1 : page,
+            PageSize = pageSize is < 1 or > 50 ? 50 : pageSize,
+        };
+
+        var result = await _repository.PaginateAsync(filter, track: false, ct);
+        return result.MapTo(ToDto);
+    }
+
+    [HttpGet("{id:long}", Name = "GetCreatureTemplateById")]
+    [ProducesResponseType(typeof(CreatureTemplateDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Get([FromRoute] ulong id, CancellationToken ct)
+    {
+        var template = await _repository.FindByIdAsync(new CreatureTemplateId(id), track: false, ct);
+        return template is null ? NotFound() : Ok(ToDto(template));
+    }
+
+    private static CreatureTemplateDto ToDto(CreatureTemplate t) => new()
+    {
+        Id = t.Id.Value,
+        Name = t.Name,
+        SubName = t.SubName,
+        IconName = t.IconName,
+        MinLevel = t.MinLevel,
+        MaxLevel = t.MaxLevel,
+        SpeedWalk = t.SpeedWalk,
+        SpeedRun = t.SpeedRun,
+        SpeedSwim = t.SpeedSwim,
+        Rank = t.Rank,
+        Family = t.Family,
+        Type = t.Type,
+        LootId = t.LootId,
+        MinGold = t.MinGold,
+        MaxGold = t.MaxGold,
+        AIName = t.AIName,
+        MovementType = t.MovementType,
+        DetectionRange = t.DetectionRange,
+        MovementId = t.MovementId,
+        ScriptName = t.ScriptName,
+        HealthModifier = t.HealthModifier,
+        ManaModifier = t.ManaModifier,
+        ArmorModifier = t.ArmorModifier,
+        ExperienceModifier = t.ExperienceModifier,
+        RegenHealth = t.RegenHealth,
+        DmgSchool = t.DmgSchool,
+        DamageModifier = t.DamageModifier,
+        BaseAttackTime = t.BaseAttackTime,
+        RangeAttackTime = t.RangeAttackTime,
+        Experience = t.Experience,
+        RespawnTimerSecs = t.RespawnTimerSecs,
+        BodyRemoveTimerSecs = t.BodyRemoveTimerSecs,
+    };
+}

--- a/src/Server/Avalon.Api/Controllers/ItemTemplateController.cs
+++ b/src/Server/Avalon.Api/Controllers/ItemTemplateController.cs
@@ -1,0 +1,95 @@
+using Avalon.Api.Authentication;
+using Avalon.Api.Contract;
+using Avalon.Common.ValueObjects;
+using Avalon.Database;
+using Avalon.Database.Extensions;
+using Avalon.Database.World.Repositories;
+using Avalon.Domain.World;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Avalon.Api.Controllers;
+
+[ApiController]
+[Authorize(Policy = AvalonRoles.Player)]
+[Route("item-template")]
+public class ItemTemplateController : BaseController
+{
+    private readonly IItemTemplateRepository _repository;
+
+    public ItemTemplateController(IItemTemplateRepository repository)
+    {
+        _repository = repository;
+    }
+
+    [HttpGet(Name = "ListItemTemplates")]
+    [ProducesResponseType(typeof(PagedResult<ItemTemplateDto>), StatusCodes.Status200OK)]
+    public async Task<PagedResult<ItemTemplateDto>> List(
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 50,
+        CancellationToken ct = default)
+    {
+        var filter = new ItemTemplatePaginateFilters
+        {
+            Page = page < 1 ? 1 : page,
+            PageSize = pageSize is < 1 or > 50 ? 50 : pageSize,
+        };
+
+        var result = await _repository.PaginateAsync(filter, track: false, ct);
+        return result.MapTo(ToDto);
+    }
+
+    [HttpGet("{id:long}", Name = "GetItemTemplateById")]
+    [ProducesResponseType(typeof(ItemTemplateDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Get([FromRoute] ulong id, CancellationToken ct)
+    {
+        var template = await _repository.FindByIdAsync(new ItemTemplateId(id), track: false, ct);
+        return template is null ? NotFound() : Ok(ToDto(template));
+    }
+
+    private static ItemTemplateDto ToDto(ItemTemplate t) => new()
+    {
+        Id = t.Id.Value,
+        Name = t.Name,
+        Class = t.Class,
+        SubClass = t.SubClass,
+        Flags = t.Flags,
+        Stackable = t.Stackable,
+        MaxStackSize = t.MaxStackSize,
+        DisplayId = t.DisplayId,
+        Rarity = t.Rarity,
+        BuyPrice = t.BuyPrice,
+        SellPrice = t.SellPrice,
+        Slot = t.Slot,
+        AllowedClasses = t.AllowedClasses is null ? [] : [..t.AllowedClasses],
+        ItemPower = t.ItemPower,
+        RequiredLevel = t.RequiredLevel,
+        DamageMin1 = t.DamageMin1,
+        DamageMax1 = t.DamageMax1,
+        DamageType1 = t.DamageType1,
+        DamageMin2 = t.DamageMin2,
+        DamageMax2 = t.DamageMax2,
+        DamageType2 = t.DamageType2,
+        StatType1 = t.StatType1,
+        StatValue1 = t.StatValue1,
+        StatType2 = t.StatType2,
+        StatValue2 = t.StatValue2,
+        StatType3 = t.StatType3,
+        StatValue3 = t.StatValue3,
+        StatType4 = t.StatType4,
+        StatValue4 = t.StatValue4,
+        StatType5 = t.StatType5,
+        StatValue5 = t.StatValue5,
+        StatType6 = t.StatType6,
+        StatValue6 = t.StatValue6,
+        StatType7 = t.StatType7,
+        StatValue7 = t.StatValue7,
+        StatType8 = t.StatType8,
+        StatValue8 = t.StatValue8,
+        StatType9 = t.StatType9,
+        StatValue9 = t.StatValue9,
+        StatType10 = t.StatType10,
+        StatValue10 = t.StatValue10,
+    };
+}

--- a/src/Server/Avalon.Api/Controllers/MapTemplateController.cs
+++ b/src/Server/Avalon.Api/Controllers/MapTemplateController.cs
@@ -1,0 +1,72 @@
+using Avalon.Api.Authentication;
+using Avalon.Api.Contract;
+using Avalon.Common.ValueObjects;
+using Avalon.Database;
+using Avalon.Database.Extensions;
+using Avalon.Database.World.Repositories;
+using Avalon.Domain.World;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Avalon.Api.Controllers;
+
+[ApiController]
+[Authorize(Policy = AvalonRoles.Player)]
+[Route("map-template")]
+public class MapTemplateController : BaseController
+{
+    private readonly IMapTemplateRepository _repository;
+
+    public MapTemplateController(IMapTemplateRepository repository)
+    {
+        _repository = repository;
+    }
+
+    [HttpGet(Name = "ListMapTemplates")]
+    [ProducesResponseType(typeof(PagedResult<MapTemplateDto>), StatusCodes.Status200OK)]
+    public async Task<PagedResult<MapTemplateDto>> List(
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 50,
+        CancellationToken ct = default)
+    {
+        var filter = new MapTemplatePaginateFilters
+        {
+            Page = page < 1 ? 1 : page,
+            PageSize = pageSize is < 1 or > 50 ? 50 : pageSize,
+        };
+
+        var result = await _repository.PaginateAsync(filter, track: false, ct);
+        return result.MapTo(ToDto);
+    }
+
+    [HttpGet("{id:int}", Name = "GetMapTemplateById")]
+    [ProducesResponseType(typeof(MapTemplateDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Get([FromRoute] ushort id, CancellationToken ct)
+    {
+        var template = await _repository.FindByIdAsync(new MapTemplateId(id), track: false, ct);
+        return template is null ? NotFound() : Ok(ToDto(template));
+    }
+
+    private static MapTemplateDto ToDto(MapTemplate t) => new()
+    {
+        Id = t.Id.Value,
+        Name = t.Name,
+        Description = t.Description,
+        Directory = t.Directory,
+        MapType = t.MapType,
+        PvP = t.PvP,
+        MinLevel = t.MinLevel,
+        MaxLevel = t.MaxLevel,
+        AreaTableId = t.AreaTableId,
+        LoadingScreenId = t.LoadingScreenId,
+        CorpseX = t.CorpseX,
+        CorpseY = t.CorpseY,
+        CorpseZ = t.CorpseZ,
+        MaxPlayers = t.MaxPlayers,
+        DefaultSpawnX = t.DefaultSpawnX,
+        DefaultSpawnY = t.DefaultSpawnY,
+        DefaultSpawnZ = t.DefaultSpawnZ,
+        ReturnMapId = t.ReturnMapId,
+    };
+}

--- a/src/Server/Avalon.Api/Controllers/SpellTemplateController.cs
+++ b/src/Server/Avalon.Api/Controllers/SpellTemplateController.cs
@@ -1,0 +1,64 @@
+using Avalon.Api.Authentication;
+using Avalon.Api.Contract;
+using Avalon.Common.ValueObjects;
+using Avalon.Database;
+using Avalon.Database.Extensions;
+using Avalon.Database.World.Repositories;
+using Avalon.Domain.World;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Avalon.Api.Controllers;
+
+[ApiController]
+[Authorize(Policy = AvalonRoles.Player)]
+[Route("spell-template")]
+public class SpellTemplateController : BaseController
+{
+    private readonly ISpellTemplateRepository _repository;
+
+    public SpellTemplateController(ISpellTemplateRepository repository)
+    {
+        _repository = repository;
+    }
+
+    [HttpGet(Name = "ListSpellTemplates")]
+    [ProducesResponseType(typeof(PagedResult<SpellTemplateDto>), StatusCodes.Status200OK)]
+    public async Task<PagedResult<SpellTemplateDto>> List(
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 50,
+        CancellationToken ct = default)
+    {
+        var filter = new SpellTemplatePaginateFilters
+        {
+            Page = page < 1 ? 1 : page,
+            PageSize = pageSize is < 1 or > 50 ? 50 : pageSize,
+        };
+
+        var result = await _repository.PaginateAsync(filter, track: false, ct);
+        return result.MapTo(ToDto);
+    }
+
+    [HttpGet("{id:long}", Name = "GetSpellTemplateById")]
+    [ProducesResponseType(typeof(SpellTemplateDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Get([FromRoute] uint id, CancellationToken ct)
+    {
+        var template = await _repository.FindByIdAsync(new SpellId(id), track: false, ct);
+        return template is null ? NotFound() : Ok(ToDto(template));
+    }
+
+    private static SpellTemplateDto ToDto(SpellTemplate t) => new()
+    {
+        Id = t.Id.Value,
+        Name = t.Name,
+        CastTime = t.CastTime,
+        Cooldown = t.Cooldown,
+        Cost = t.Cost,
+        SpellScript = t.SpellScript,
+        Range = t.Range,
+        Effects = t.Effects,
+        EffectValue = t.EffectValue,
+        AllowedClasses = t.AllowedClasses is null ? [] : [..t.AllowedClasses],
+    };
+}

--- a/src/Server/Avalon.Api/Controllers/WorldController.cs
+++ b/src/Server/Avalon.Api/Controllers/WorldController.cs
@@ -1,0 +1,61 @@
+using Avalon.Api.Authentication;
+using Avalon.Api.Contract;
+using Avalon.Api.Services;
+using Avalon.Database;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Avalon.Api.Controllers;
+
+[ApiController]
+[Authorize(Policy = AvalonRoles.Player)]
+[Route("world")]
+public class WorldController : BaseController
+{
+    private readonly IWorldService _service;
+
+    public WorldController(IWorldService service)
+    {
+        _service = service;
+    }
+
+    [HttpGet(Name = "ListWorlds")]
+    [ProducesResponseType(typeof(PagedResult<WorldDto>), StatusCodes.Status200OK)]
+    public Task<PagedResult<WorldDto>> List(
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 50,
+        CancellationToken ct = default) =>
+        _service.ListAsync(page, pageSize, ct);
+
+    [HttpGet("{id}", Name = "GetWorldById")]
+    [ProducesResponseType(typeof(WorldDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Get([FromRoute] ushort id, CancellationToken ct)
+    {
+        var world = await _service.GetAsync(id, ct);
+        return world is null ? NotFound() : Ok(world);
+    }
+
+    [HttpPost(Name = "CreateWorld")]
+    [Authorize(Policy = AvalonRoles.Admin)]
+    [ProducesResponseType(typeof(WorldDto), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> Create([FromBody] CreateWorldRequest request, CancellationToken ct)
+    {
+        var world = await _service.CreateAsync(request, ct);
+        return CreatedAtAction(nameof(Get), new { id = world.Id }, world);
+    }
+
+    [HttpPatch("{id}", Name = "UpdateWorld")]
+    [Authorize(Policy = AvalonRoles.Admin)]
+    [ProducesResponseType(typeof(WorldDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> Update(
+        [FromRoute] ushort id,
+        [FromBody] UpdateWorldRequest request,
+        CancellationToken ct)
+    {
+        var world = await _service.UpdateAsync(id, request, ct);
+        return world is null ? NotFound() : Ok(world);
+    }
+}

--- a/src/Server/Avalon.Api/ServiceRegistration.cs
+++ b/src/Server/Avalon.Api/ServiceRegistration.cs
@@ -33,6 +33,7 @@ public static class ServiceRegistration
 
         services.AddScoped<IAccountService, AccountService>();
         services.AddScoped<ICharacterService, CharacterService>();
+        services.AddScoped<IWorldService, WorldService>();
         services.AddMfaService();
         services.AddSecureRandom();
         services.AddSingleton<IReplicatedCache, ReplicatedCache>();

--- a/src/Server/Avalon.Api/ServiceRegistration.cs
+++ b/src/Server/Avalon.Api/ServiceRegistration.cs
@@ -34,6 +34,7 @@ public static class ServiceRegistration
         services.AddScoped<IAccountService, AccountService>();
         services.AddScoped<ICharacterService, CharacterService>();
         services.AddMfaService();
+        services.AddSecureRandom();
         services.AddSingleton<IReplicatedCache, ReplicatedCache>();
         services.AddScoped<INotificationService, NotificationService>();
         services.AddScoped<IJwtUtils, JwtUtils>();

--- a/src/Server/Avalon.Api/Services/AccountService.cs
+++ b/src/Server/Avalon.Api/Services/AccountService.cs
@@ -21,6 +21,7 @@ public interface IAccountService
         CancellationToken cancellationToken);
 
     Task<PagedResult<Account>> Paginate(AccountPaginateFilters filters, CancellationToken cancellationToken = default);
+    Task ChangePasswordAsync(AccountId accountId, string currentPassword, string newPassword, CancellationToken cancellationToken = default);
 }
 
 public class AccountService : IAccountService
@@ -149,5 +150,27 @@ public class AccountService : IAccountService
     public async Task<PagedResult<Account>> Paginate(AccountPaginateFilters filters, CancellationToken cancellationToken)
     {
         return await _accountRepository.PaginateAsync(filters, false, cancellationToken);
+    }
+
+    public async Task ChangePasswordAsync(AccountId accountId, string currentPassword, string newPassword,
+        CancellationToken cancellationToken = default)
+    {
+        var account = await _accountRepository.FindByIdAsync(accountId, track: true, cancellationToken);
+        if (account == null)
+            throw new AuthenticationException("Invalid current password");
+
+        var existingHash = Encoding.UTF8.GetString(account.Verifier);
+        if (!BCrypt.Net.BCrypt.Verify(currentPassword, existingHash))
+        {
+            throw new AuthenticationException("Invalid current password");
+        }
+
+        var salt = BCrypt.Net.BCrypt.GenerateSalt();
+        var hash = BCrypt.Net.BCrypt.HashPassword(newPassword.Trim(), salt);
+
+        account.Salt = Encoding.UTF8.GetBytes(salt);
+        account.Verifier = Encoding.UTF8.GetBytes(hash);
+
+        await _accountRepository.UpdateAsync(account, cancellationToken);
     }
 }

--- a/src/Server/Avalon.Api/Services/AccountService.cs
+++ b/src/Server/Avalon.Api/Services/AccountService.cs
@@ -8,6 +8,7 @@ using Avalon.Common.ValueObjects;
 using Avalon.Database;
 using Avalon.Database.Auth.Repositories;
 using Avalon.Domain.Auth;
+using Avalon.Infrastructure;
 using Avalon.Infrastructure.Services;
 using OperatingSystem = Avalon.Domain.Auth.OperatingSystem;
 
@@ -22,6 +23,8 @@ public interface IAccountService
 
     Task<PagedResult<Account>> Paginate(AccountPaginateFilters filters, CancellationToken cancellationToken = default);
     Task ChangePasswordAsync(AccountId accountId, string currentPassword, string newPassword, CancellationToken cancellationToken = default);
+    Task<string> InitiateEmailChangeAsync(AccountId accountId, string newEmail, CancellationToken cancellationToken = default);
+    Task ConfirmEmailChangeAsync(string token, CancellationToken cancellationToken = default);
 }
 
 public class AccountService : IAccountService
@@ -32,12 +35,16 @@ public class AccountService : IAccountService
     private readonly IMFAHashService _mfaHashService;
     private readonly IMfaSetupRepository _mfaSetupRepository;
     private readonly IDeviceRepository _deviceRepository;
+    private readonly IReplicatedCache _cache;
+    private readonly ISecureRandom _secureRandom;
     public AccountService(ILoggerFactory loggerFactory,
         IAccountRepository accountRepository,
         IJwtUtils jwtUtils,
         IMFAHashService mfaHashService,
         IMfaSetupRepository mfaSetupRepository,
-        IDeviceRepository deviceRepository)
+        IDeviceRepository deviceRepository,
+        IReplicatedCache cache,
+        ISecureRandom secureRandom)
     {
         _logger = loggerFactory.CreateLogger<AccountService>();
         _accountRepository = accountRepository;
@@ -45,6 +52,8 @@ public class AccountService : IAccountService
         _mfaHashService = mfaHashService;
         _mfaSetupRepository = mfaSetupRepository;
         _deviceRepository = deviceRepository;
+        _cache = cache;
+        _secureRandom = secureRandom;
     }
 
     public async Task<Account?> FindByIdAsync(AccountId id, CancellationToken cancellationToken = default)
@@ -171,6 +180,40 @@ public class AccountService : IAccountService
         account.Salt = Encoding.UTF8.GetBytes(salt);
         account.Verifier = Encoding.UTF8.GetBytes(hash);
 
+        await _accountRepository.UpdateAsync(account, cancellationToken);
+    }
+
+    public async Task<string> InitiateEmailChangeAsync(AccountId accountId, string newEmail,
+        CancellationToken cancellationToken = default)
+    {
+        var raw = _secureRandom.GetBytes(24);
+        var token = Convert.ToBase64String(raw).Replace("+", "-").Replace("/", "_").TrimEnd('=');
+
+        var payload = $"{accountId.Value}|{newEmail}";
+        var key = $"auth:emailChange:{token}";
+        await _cache.SetAsync(key, payload, TimeSpan.FromMinutes(15));
+
+        return token;
+    }
+
+    public async Task ConfirmEmailChangeAsync(string token, CancellationToken cancellationToken = default)
+    {
+        var key = $"auth:emailChange:{token}";
+        var payload = await _cache.GetAsync(key)
+            ?? throw new BusinessException("Invalid or expired token");
+        await _cache.RemoveAsync(key);
+
+        var parts = payload.Split('|', 2);
+        if (parts.Length != 2)
+            throw new BusinessException("Invalid token payload");
+
+        var accountId = new AccountId(long.Parse(parts[0]));
+        var newEmail = parts[1];
+
+        var account = await _accountRepository.FindByIdAsync(accountId, track: true, cancellationToken)
+            ?? throw new BusinessException("Account not found");
+
+        account.Email = newEmail;
         await _accountRepository.UpdateAsync(account, cancellationToken);
     }
 }

--- a/src/Server/Avalon.Api/Services/AccountService.cs
+++ b/src/Server/Avalon.Api/Services/AccountService.cs
@@ -25,6 +25,7 @@ public interface IAccountService
     Task ChangePasswordAsync(AccountId accountId, string currentPassword, string newPassword, CancellationToken cancellationToken = default);
     Task<string> InitiateEmailChangeAsync(AccountId accountId, string newEmail, CancellationToken cancellationToken = default);
     Task ConfirmEmailChangeAsync(string token, CancellationToken cancellationToken = default);
+    Task UpdateStatusAsync(AccountId accountId, AccountStatus state, string? reason, CancellationToken cancellationToken = default);
 }
 
 public class AccountService : IAccountService
@@ -215,5 +216,21 @@ public class AccountService : IAccountService
 
         account.Email = newEmail;
         await _accountRepository.UpdateAsync(account, cancellationToken);
+    }
+
+    // NOTE: `reason` is currently accepted but not persisted (future: audit log).
+    public async Task UpdateStatusAsync(AccountId accountId, AccountStatus state, string? reason,
+        CancellationToken cancellationToken = default)
+    {
+        var account = await _accountRepository.FindByIdAsync(accountId, track: true, cancellationToken)
+            ?? throw new BusinessException("Account not found");
+
+        account.Status = state;
+        await _accountRepository.UpdateAsync(account, cancellationToken);
+
+        if (state == AccountStatus.Banned || state == AccountStatus.Deactivated)
+        {
+            await _cache.PublishAsync(CacheKeys.WorldAccountsDisconnectChannel, accountId.Value.ToString());
+        }
     }
 }

--- a/src/Server/Avalon.Api/Services/AccountService.cs
+++ b/src/Server/Avalon.Api/Services/AccountService.cs
@@ -26,6 +26,7 @@ public interface IAccountService
     Task<string> InitiateEmailChangeAsync(AccountId accountId, string newEmail, CancellationToken cancellationToken = default);
     Task ConfirmEmailChangeAsync(string token, CancellationToken cancellationToken = default);
     Task UpdateStatusAsync(AccountId accountId, AccountStatus state, string? reason, CancellationToken cancellationToken = default);
+    Task UpdateRolesAsync(AccountId accountId, AccountAccessLevel roles, CancellationToken cancellationToken = default);
 }
 
 public class AccountService : IAccountService
@@ -232,5 +233,13 @@ public class AccountService : IAccountService
         {
             await _cache.PublishAsync(CacheKeys.WorldAccountsDisconnectChannel, accountId.Value.ToString());
         }
+    }
+
+    public async Task UpdateRolesAsync(AccountId accountId, AccountAccessLevel roles, CancellationToken cancellationToken = default)
+    {
+        var account = await _accountRepository.FindByIdAsync(accountId, track: true, cancellationToken)
+            ?? throw new BusinessException("Account not found");
+        account.AccessLevel = roles;
+        await _accountRepository.UpdateAsync(account, cancellationToken);
     }
 }

--- a/src/Server/Avalon.Api/Services/CharacterService.cs
+++ b/src/Server/Avalon.Api/Services/CharacterService.cs
@@ -1,3 +1,5 @@
+using Avalon.Api.Contract;
+using Avalon.Api.Exceptions;
 using Avalon.Common.ValueObjects;
 using Avalon.Database.Character.Repositories;
 using Avalon.Domain.Characters;
@@ -8,6 +10,8 @@ public interface ICharacterService
 {
     Task<List<Character>> GetAllCharactersAsync(AccountId id, CancellationToken cancellationToken = default);
     Task<Character?> GetCharacterByIdAsync(CharacterId id, CancellationToken cancellationToken = default);
+    Task UpdateCosmeticAsync(Character character, string? newName, CancellationToken cancellationToken = default);
+    Task UpdateAnyAsync(Character character, CharacterPatchDto dto, CancellationToken cancellationToken = default);
 }
 
 public class CharacterService : ICharacterService
@@ -24,4 +28,35 @@ public class CharacterService : ICharacterService
 
     public Task<Character?> GetCharacterByIdAsync(CharacterId id, CancellationToken cancellationToken = default) =>
         _characterRepository.FindByIdAsync(id, track: false, cancellationToken);
+
+    public async Task UpdateCosmeticAsync(Character character, string? newName, CancellationToken cancellationToken = default)
+    {
+        if (!string.IsNullOrWhiteSpace(newName) && newName != character.Name)
+        {
+            var existing = await _characterRepository.FindByNameAsync(newName, cancellationToken);
+            if (existing is not null && existing.Id != character.Id)
+                throw new BusinessException("Name already taken");
+
+            character.Name = newName;
+        }
+        await _characterRepository.UpdateAsync(character, cancellationToken);
+    }
+
+    public async Task UpdateAnyAsync(Character character, CharacterPatchDto dto, CancellationToken cancellationToken = default)
+    {
+        if (dto.Name is not null && dto.Name != character.Name)
+        {
+            var existing = await _characterRepository.FindByNameAsync(dto.Name, cancellationToken);
+            if (existing is not null && existing.Id != character.Id)
+                throw new BusinessException("Name already taken");
+            character.Name = dto.Name;
+        }
+        if (dto.Level.HasValue)      character.Level = dto.Level.Value;
+        if (dto.Experience.HasValue) character.Experience = dto.Experience.Value;
+        if (dto.Health.HasValue)     character.Health = dto.Health.Value;
+        if (dto.Power1.HasValue)     character.Power1 = dto.Power1.Value;
+        if (dto.Power2.HasValue)     character.Power2 = dto.Power2.Value;
+
+        await _characterRepository.UpdateAsync(character, cancellationToken);
+    }
 }

--- a/src/Server/Avalon.Api/Services/CharacterService.cs
+++ b/src/Server/Avalon.Api/Services/CharacterService.cs
@@ -12,15 +12,20 @@ public interface ICharacterService
     Task<Character?> GetCharacterByIdAsync(CharacterId id, CancellationToken cancellationToken = default);
     Task UpdateCosmeticAsync(Character character, string? newName, CancellationToken cancellationToken = default);
     Task UpdateAnyAsync(Character character, CharacterPatchDto dto, CancellationToken cancellationToken = default);
+    Task<CharacterInventoryDto?> GetInventoryAsync(CharacterId id, CancellationToken cancellationToken = default);
 }
 
 public class CharacterService : ICharacterService
 {
     private readonly ICharacterRepository _characterRepository;
+    private readonly ICharacterInventoryRepository _inventoryRepository;
 
-    public CharacterService(ICharacterRepository characterRepository)
+    public CharacterService(
+        ICharacterRepository characterRepository,
+        ICharacterInventoryRepository inventoryRepository)
     {
         _characterRepository = characterRepository;
+        _inventoryRepository = inventoryRepository;
     }
 
     public Task<List<Character>> GetAllCharactersAsync(AccountId id, CancellationToken cancellationToken = default) =>
@@ -59,4 +64,25 @@ public class CharacterService : ICharacterService
 
         await _characterRepository.UpdateAsync(character, cancellationToken);
     }
+
+    public async Task<CharacterInventoryDto?> GetInventoryAsync(CharacterId id, CancellationToken cancellationToken = default)
+    {
+        var character = await _characterRepository.FindByIdAsync(id, track: false, cancellationToken);
+        if (character is null) return null;
+
+        var items = await _inventoryRepository.GetByCharacterIdAsync(id);
+
+        return new CharacterInventoryDto
+        {
+            CharacterId = character.Id.Value,
+            Items = items.Select(MapItem).ToList(),
+        };
+    }
+
+    private static CharacterInventoryItemDto MapItem(CharacterInventory i) => new()
+    {
+        ItemId = i.ItemId.Value,
+        Container = i.Container,
+        Slot = i.Slot,
+    };
 }

--- a/src/Server/Avalon.Api/Services/CharacterService.cs
+++ b/src/Server/Avalon.Api/Services/CharacterService.cs
@@ -1,6 +1,7 @@
 using Avalon.Api.Contract;
 using Avalon.Api.Exceptions;
 using Avalon.Common.ValueObjects;
+using Avalon.Database;
 using Avalon.Database.Character.Repositories;
 using Avalon.Domain.Characters;
 
@@ -13,6 +14,7 @@ public interface ICharacterService
     Task UpdateCosmeticAsync(Character character, string? newName, CancellationToken cancellationToken = default);
     Task UpdateAnyAsync(Character character, CharacterPatchDto dto, CancellationToken cancellationToken = default);
     Task<CharacterInventoryDto?> GetInventoryAsync(CharacterId id, CancellationToken cancellationToken = default);
+    Task<PagedResult<Character>> PaginateAsync(CharacterPaginateFilters filters, CancellationToken cancellationToken = default);
 }
 
 public class CharacterService : ICharacterService
@@ -33,6 +35,9 @@ public class CharacterService : ICharacterService
 
     public Task<Character?> GetCharacterByIdAsync(CharacterId id, CancellationToken cancellationToken = default) =>
         _characterRepository.FindByIdAsync(id, track: false, cancellationToken);
+
+    public Task<PagedResult<Character>> PaginateAsync(CharacterPaginateFilters filters, CancellationToken cancellationToken = default) =>
+        _characterRepository.PaginateAsync(filters, track: false, cancellationToken);
 
     public async Task UpdateCosmeticAsync(Character character, string? newName, CancellationToken cancellationToken = default)
     {

--- a/src/Server/Avalon.Api/Services/WorldService.cs
+++ b/src/Server/Avalon.Api/Services/WorldService.cs
@@ -1,0 +1,107 @@
+using Avalon.Api.Contract;
+using Avalon.Api.Exceptions;
+using Avalon.Database;
+using Avalon.Database.Auth.Repositories;
+using Avalon.Database.Extensions;
+using Avalon.Domain.Auth;
+using WorldEntity = Avalon.Domain.Auth.World;
+
+namespace Avalon.Api.Services;
+
+public interface IWorldService
+{
+    Task<PagedResult<WorldDto>> ListAsync(int page, int pageSize, CancellationToken cancellationToken = default);
+    Task<WorldDto?> GetAsync(ushort id, CancellationToken cancellationToken = default);
+    Task<WorldDto> CreateAsync(CreateWorldRequest request, CancellationToken cancellationToken = default);
+    Task<WorldDto?> UpdateAsync(ushort id, UpdateWorldRequest request, CancellationToken cancellationToken = default);
+}
+
+public class WorldService : IWorldService
+{
+    private readonly IWorldRepository _repository;
+
+    public WorldService(IWorldRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<PagedResult<WorldDto>> ListAsync(int page, int pageSize, CancellationToken cancellationToken = default)
+    {
+        var filters = new WorldPaginateFilters
+        {
+            Page = page < 1 ? 1 : page,
+            PageSize = pageSize is < 1 or > 50 ? 50 : pageSize,
+        };
+
+        var result = await _repository.PaginateAsync(filters, track: false, cancellationToken);
+        return result.MapTo(ToDto);
+    }
+
+    public async Task<WorldDto?> GetAsync(ushort id, CancellationToken cancellationToken = default)
+    {
+        var world = await _repository.FindByIdAsync(new WorldId(id), track: false, cancellationToken);
+        return world is null ? null : ToDto(world);
+    }
+
+    public async Task<WorldDto> CreateAsync(CreateWorldRequest request, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(request.Name))
+            throw new BusinessException("Name is required");
+        if (string.IsNullOrWhiteSpace(request.Host))
+            throw new BusinessException("Host is required");
+
+        var now = DateTime.UtcNow;
+        var world = new WorldEntity
+        {
+            Name = request.Name,
+            Host = request.Host,
+            Port = request.Port,
+            MinVersion = request.MinVersion,
+            Version = request.Version,
+            Type = request.Type,
+            AccessLevelRequired = request.AccessLevelRequired,
+            Status = request.Status,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+
+        var created = await _repository.CreateAsync(world, cancellationToken);
+        return ToDto(created);
+    }
+
+    public async Task<WorldDto?> UpdateAsync(ushort id, UpdateWorldRequest request, CancellationToken cancellationToken = default)
+    {
+        var world = await _repository.FindByIdAsync(new WorldId(id), track: true, cancellationToken);
+        if (world is null) return null;
+
+        if (request.Name is not null) world.Name = request.Name;
+        if (request.Host is not null) world.Host = request.Host;
+        if (request.Port.HasValue) world.Port = request.Port.Value;
+        if (request.MinVersion is not null) world.MinVersion = request.MinVersion;
+        if (request.Version is not null) world.Version = request.Version;
+        if (request.Type.HasValue) world.Type = request.Type.Value;
+        if (request.AccessLevelRequired.HasValue) world.AccessLevelRequired = request.AccessLevelRequired.Value;
+        if (request.Status.HasValue) world.Status = request.Status.Value;
+
+        world.UpdatedAt = DateTime.UtcNow;
+
+        await _repository.UpdateAsync(world, cancellationToken);
+        return ToDto(world);
+    }
+
+    private static WorldDto ToDto(WorldEntity w) => new()
+    {
+        Id = w.Id.Value,
+        Name = w.Name,
+        Type = w.Type,
+        AccessLevelRequired = w.AccessLevelRequired,
+        Host = w.Host,
+        Port = w.Port,
+        MinVersion = w.MinVersion,
+        Version = w.Version,
+        Status = w.Status,
+        CreatedAt = w.CreatedAt,
+        UpdatedAt = w.UpdatedAt,
+        OnlineCount = 0,
+    };
+}

--- a/src/Server/Avalon.Database.Auth/Migrations/20260422043444_AddAccountStatus.Designer.cs
+++ b/src/Server/Avalon.Database.Auth/Migrations/20260422043444_AddAccountStatus.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Avalon.Database.Auth;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Avalon.Database.Auth.Migrations
 {
     [DbContext(typeof(AuthDbContext))]
-    partial class AuthDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260422043444_AddAccountStatus")]
+    partial class AddAccountStatus
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Server/Avalon.Database.Auth/Migrations/20260422043444_AddAccountStatus.cs
+++ b/src/Server/Avalon.Database.Auth/Migrations/20260422043444_AddAccountStatus.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Avalon.Database.Auth.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAccountStatus : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<byte>(
+                name: "Status",
+                table: "Accounts",
+                type: "smallint",
+                nullable: false,
+                defaultValue: (byte)0);
+
+            migrationBuilder.UpdateData(
+                table: "Accounts",
+                keyColumn: "Id",
+                keyValue: 1L,
+                column: "Status",
+                value: (byte)0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Status",
+                table: "Accounts");
+        }
+    }
+}

--- a/src/Shared/Avalon.Domain/Auth/Account.cs
+++ b/src/Shared/Avalon.Domain/Auth/Account.cs
@@ -53,6 +53,8 @@ public class Account : IDbEntity<AccountId>
     public long TotalTime { get; set; } = 0;
 
     public AccountAccessLevel AccessLevel { get; set; } = AccountAccessLevel.Player;
+
+    public AccountStatus Status { get; set; } = AccountStatus.Active;
 }
 
 
@@ -96,4 +98,11 @@ public enum OperatingSystem : ushort
     Windows,
     MacOS,
     Linux
+}
+
+public enum AccountStatus : byte
+{
+    Active = 0,
+    Banned = 1,
+    Deactivated = 2
 }

--- a/src/Shared/Avalon.Domain/Auth/Account.cs
+++ b/src/Shared/Avalon.Domain/Auth/Account.cs
@@ -23,7 +23,7 @@ public class Account : IDbEntity<AccountId>
     public byte[] SessionKey { get; set; } = [];
 
     [Required]
-    public required string Email { get; init; }
+    public required string Email { get; set; }
 
     [Required]
     public required DateTime JoinDate { get; init; } = DateTime.UtcNow;

--- a/src/Shared/Avalon.Domain/Auth/Account.cs
+++ b/src/Shared/Avalon.Domain/Auth/Account.cs
@@ -14,10 +14,10 @@ public class Account : IDbEntity<AccountId>
     public required string Username { get; init; }
 
     [Required]
-    public required byte[] Salt { get; init; }
+    public required byte[] Salt { get; set; }
 
     [Required]
-    public required byte[] Verifier { get; init; }
+    public required byte[] Verifier { get; set; }
 
     [Column("SessionKey")]
     public byte[] SessionKey { get; set; } = [];

--- a/tests/Avalon.Api.UnitTests/Controllers/AccountControllerShould.cs
+++ b/tests/Avalon.Api.UnitTests/Controllers/AccountControllerShould.cs
@@ -116,4 +116,31 @@ public class AccountControllerShould
         await _accountService.Received(1).ChangePasswordAsync(
             new AccountId(7), "a", "newstrong1", Arg.Any<CancellationToken>());
     }
+
+    [Fact]
+    public async Task InitiateEmailChange_Delegates()
+    {
+        var user = User(7, AvalonRoles.Player);
+        _accountService.InitiateEmailChangeAsync(new AccountId(7), "new@t", Arg.Any<CancellationToken>())
+            .Returns("tok");
+
+        var sut = MakeSut(user);
+        var result = await sut.InitiateEmailChange(
+            new AccountEmailChangeRequest { NewEmail = "new@t" }, CancellationToken.None);
+
+        Assert.IsType<AcceptedResult>(result);
+    }
+
+    [Fact]
+    public async Task ConfirmEmailChange_Delegates()
+    {
+        var user = User(7, AvalonRoles.Player);
+        var sut = MakeSut(user);
+
+        var result = await sut.ConfirmEmailChange(
+            new AccountEmailConfirmRequest { Token = "tok" }, CancellationToken.None);
+
+        Assert.IsType<NoContentResult>(result);
+        await _accountService.Received(1).ConfirmEmailChangeAsync("tok", Arg.Any<CancellationToken>());
+    }
 }

--- a/tests/Avalon.Api.UnitTests/Controllers/AccountControllerShould.cs
+++ b/tests/Avalon.Api.UnitTests/Controllers/AccountControllerShould.cs
@@ -1,5 +1,6 @@
 using System.Security.Claims;
 using Avalon.Api.Authentication;
+using Avalon.Api.Contract;
 using Avalon.Api.Controllers;
 using Avalon.Api.Services;
 using Avalon.Common.ValueObjects;
@@ -100,5 +101,19 @@ public class AccountControllerShould
         var result = await sut.FindById(7, CancellationToken.None);
 
         Assert.IsType<ForbidResult>(result);
+    }
+
+    [Fact]
+    public async Task ChangePassword_DelegatesToService()
+    {
+        var user = User(7, AvalonRoles.Player);
+        var sut = MakeSut(user);
+
+        await sut.ChangePassword(
+            new AccountPasswordChangeRequest { CurrentPassword = "a", NewPassword = "newstrong1" },
+            CancellationToken.None);
+
+        await _accountService.Received(1).ChangePasswordAsync(
+            new AccountId(7), "a", "newstrong1", Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Avalon.Api.UnitTests/Controllers/AccountControllerShould.cs
+++ b/tests/Avalon.Api.UnitTests/Controllers/AccountControllerShould.cs
@@ -143,4 +143,19 @@ public class AccountControllerShould
         Assert.IsType<NoContentResult>(result);
         await _accountService.Received(1).ConfirmEmailChangeAsync("tok", Arg.Any<CancellationToken>());
     }
+
+    [Fact]
+    public async Task UpdateStatus_Delegates()
+    {
+        var user = User(99, AvalonRoles.Admin);
+        var sut = MakeSut(user);
+
+        var result = await sut.UpdateStatus(7,
+            new AccountStatusPatchRequest { State = AccountStatus.Banned, Reason = "cheat" },
+            CancellationToken.None);
+
+        Assert.IsType<NoContentResult>(result);
+        await _accountService.Received(1).UpdateStatusAsync(
+            new AccountId(7), AccountStatus.Banned, "cheat", Arg.Any<CancellationToken>());
+    }
 }

--- a/tests/Avalon.Api.UnitTests/Controllers/AccountControllerShould.cs
+++ b/tests/Avalon.Api.UnitTests/Controllers/AccountControllerShould.cs
@@ -158,4 +158,21 @@ public class AccountControllerShould
         await _accountService.Received(1).UpdateStatusAsync(
             new AccountId(7), AccountStatus.Banned, "cheat", Arg.Any<CancellationToken>());
     }
+
+    [Fact]
+    public async Task UpdateRoles_Delegates()
+    {
+        var user = User(99, AvalonRoles.Console);
+        var sut = MakeSut(user);
+
+        var result = await sut.UpdateRoles(7,
+            new AccountRolesPatchRequest { Roles = AccountAccessLevel.Player | AccountAccessLevel.GameMaster },
+            CancellationToken.None);
+
+        Assert.IsType<NoContentResult>(result);
+        await _accountService.Received(1).UpdateRolesAsync(
+            new AccountId(7),
+            AccountAccessLevel.Player | AccountAccessLevel.GameMaster,
+            Arg.Any<CancellationToken>());
+    }
 }

--- a/tests/Avalon.Api.UnitTests/Controllers/CharacterControllerShould.cs
+++ b/tests/Avalon.Api.UnitTests/Controllers/CharacterControllerShould.cs
@@ -147,4 +147,49 @@ public class CharacterControllerShould
 
         await _service.Received(1).UpdateAnyAsync(ch, dto, Arg.Any<CancellationToken>());
     }
+
+    [Fact]
+    public async Task GetInventory_Returns200_WhenAuthzSucceeds()
+    {
+        var user = User(7, AvalonRoles.Player);
+        var ch = MakeChar(7);
+        _service.GetCharacterByIdAsync(Arg.Any<CharacterId>(), Arg.Any<CancellationToken>()).Returns(ch);
+        _authz.AuthorizeAsync(user, ch, Arg.Any<IEnumerable<IAuthorizationRequirement>>())
+              .Returns(AuthorizationResult.Success());
+        _service.GetInventoryAsync(new CharacterId(42), Arg.Any<CancellationToken>())
+            .Returns(new CharacterInventoryDto { CharacterId = 42 });
+
+        var sut = MakeSut(user);
+        var result = await sut.GetInventory(42, CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task GetInventory_Returns404_WhenCharacterMissing()
+    {
+        var user = User(7, AvalonRoles.Player);
+        _service.GetCharacterByIdAsync(Arg.Any<CharacterId>(), Arg.Any<CancellationToken>())
+            .Returns((Character?)null);
+
+        var sut = MakeSut(user);
+        var result = await sut.GetInventory(42, CancellationToken.None);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task GetInventory_Returns404_WhenAuthzFailsAndCallerIsPlayer()
+    {
+        var user = User(7, AvalonRoles.Player);
+        var ch = MakeChar(99);
+        _service.GetCharacterByIdAsync(Arg.Any<CharacterId>(), Arg.Any<CancellationToken>()).Returns(ch);
+        _authz.AuthorizeAsync(user, ch, Arg.Any<IEnumerable<IAuthorizationRequirement>>())
+              .Returns(AuthorizationResult.Failed());
+
+        var sut = MakeSut(user);
+        var result = await sut.GetInventory(42, CancellationToken.None);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
 }

--- a/tests/Avalon.Api.UnitTests/Controllers/CharacterControllerShould.cs
+++ b/tests/Avalon.Api.UnitTests/Controllers/CharacterControllerShould.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using Avalon.Api.Authentication;
 using Avalon.Api.Authorization;
+using Avalon.Api.Contract;
 using Avalon.Api.Controllers;
 using Avalon.Api.Services;
 using Avalon.Common.ValueObjects;
@@ -99,5 +100,51 @@ public class CharacterControllerShould
         var result = await sut.GetById(42, CancellationToken.None);
 
         Assert.IsType<ForbidResult>(result);
+    }
+
+    [Fact]
+    public async Task Patch_Returns404_WhenCharacterMissing()
+    {
+        var user = User(7, AvalonRoles.Player);
+        _service.GetCharacterByIdAsync(Arg.Any<CharacterId>(), Arg.Any<CancellationToken>())
+            .Returns((Character?)null);
+
+        var sut = MakeSut(user);
+        var result = await sut.Patch(42, new CharacterPatchDto { Name = "x" }, CancellationToken.None);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task Patch_OwnerPlayer_CallsUpdateCosmeticOnly()
+    {
+        var user = User(7, AvalonRoles.Player);
+        var ch = MakeChar(7);
+        _service.GetCharacterByIdAsync(Arg.Any<CharacterId>(), Arg.Any<CancellationToken>()).Returns(ch);
+        _authz.AuthorizeAsync(user, ch, Arg.Any<IEnumerable<IAuthorizationRequirement>>())
+              .Returns(AuthorizationResult.Success());
+
+        var sut = MakeSut(user);
+        var dto = new CharacterPatchDto { Name = "new", Level = 99 };
+        await sut.Patch(42, dto, CancellationToken.None);
+
+        await _service.Received(1).UpdateCosmeticAsync(ch, "new", Arg.Any<CancellationToken>());
+        await _service.DidNotReceive().UpdateAnyAsync(Arg.Any<Character>(), Arg.Any<CharacterPatchDto>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Patch_Admin_CallsUpdateAny()
+    {
+        var user = User(99, AvalonRoles.Admin);
+        var ch = MakeChar(7);
+        _service.GetCharacterByIdAsync(Arg.Any<CharacterId>(), Arg.Any<CancellationToken>()).Returns(ch);
+        _authz.AuthorizeAsync(user, ch, Arg.Any<IEnumerable<IAuthorizationRequirement>>())
+              .Returns(AuthorizationResult.Success());
+
+        var sut = MakeSut(user);
+        var dto = new CharacterPatchDto { Level = 99 };
+        await sut.Patch(42, dto, CancellationToken.None);
+
+        await _service.Received(1).UpdateAnyAsync(ch, dto, Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Avalon.Api.UnitTests/Controllers/CharacterControllerShould.cs
+++ b/tests/Avalon.Api.UnitTests/Controllers/CharacterControllerShould.cs
@@ -5,6 +5,7 @@ using Avalon.Api.Contract;
 using Avalon.Api.Controllers;
 using Avalon.Api.Services;
 using Avalon.Common.ValueObjects;
+using Avalon.Database;
 using Avalon.Domain.Characters;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -176,6 +177,19 @@ public class CharacterControllerShould
         var result = await sut.GetInventory(42, CancellationToken.None);
 
         Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task Paginate_ReturnsMappedResult()
+    {
+        var user = User(99, AvalonRoles.GameMaster);
+        _service.PaginateAsync(Arg.Any<CharacterPaginateFilters>(), Arg.Any<CancellationToken>())
+            .Returns(new PagedResult<Character>(1, 50, 1, new List<Character> { MakeChar(7) }));
+
+        var sut = MakeSut(user);
+        var result = await sut.Paginate(new CharacterPaginateFilters(), CancellationToken.None);
+
+        Assert.Single(result.Items);
     }
 
     [Fact]

--- a/tests/Avalon.Api.UnitTests/Controllers/CreatureTemplateControllerShould.cs
+++ b/tests/Avalon.Api.UnitTests/Controllers/CreatureTemplateControllerShould.cs
@@ -1,0 +1,73 @@
+using System.Security.Claims;
+using Avalon.Api.Authentication;
+using Avalon.Api.Controllers;
+using Avalon.Common.ValueObjects;
+using Avalon.Database;
+using Avalon.Database.World.Repositories;
+using Avalon.Domain.World;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using Xunit;
+
+namespace Avalon.Api.UnitTests.Controllers;
+
+public class CreatureTemplateControllerShould
+{
+    private readonly ICreatureTemplateRepository _repository = Substitute.For<ICreatureTemplateRepository>();
+
+    private CreatureTemplateController MakeSut(ClaimsPrincipal user) =>
+        new(_repository)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext { User = user }
+            }
+        };
+
+    private static ClaimsPrincipal User(long accountId, params string[] roles)
+    {
+        var claims = new List<Claim> { new(ClaimTypes.NameIdentifier, accountId.ToString()) };
+        claims.AddRange(roles.Select(r => new Claim(ClaimTypes.Role, r)));
+        return new(new ClaimsIdentity(claims, "test", ClaimTypes.NameIdentifier, ClaimTypes.Role));
+    }
+
+    [Fact]
+    public async Task List_ReturnsPage()
+    {
+        _repository
+            .PaginateAsync(Arg.Any<EntityPaginateFilter<CreatureTemplate>>(), false, Arg.Any<CancellationToken>())
+            .Returns(new PagedResult<CreatureTemplate>(1, 50, 0, new List<CreatureTemplate>()));
+
+        var sut = MakeSut(User(7, AvalonRoles.Player));
+        var result = await sut.List(1, 50, CancellationToken.None);
+
+        Assert.Equal(0, result.TotalCount);
+    }
+
+    [Fact]
+    public async Task Get_Returns404_WhenMissing()
+    {
+        _repository
+            .FindByIdAsync(Arg.Any<CreatureTemplateId>(), false, Arg.Any<CancellationToken>())
+            .Returns((CreatureTemplate?)null);
+
+        var sut = MakeSut(User(7, AvalonRoles.Player));
+        var result = await sut.Get(1, CancellationToken.None);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task Get_Returns200_WhenFound()
+    {
+        _repository
+            .FindByIdAsync(Arg.Any<CreatureTemplateId>(), false, Arg.Any<CancellationToken>())
+            .Returns(new CreatureTemplate { Id = new CreatureTemplateId(1), Name = "Goblin" });
+
+        var sut = MakeSut(User(7, AvalonRoles.Player));
+        var result = await sut.Get(1, CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+}

--- a/tests/Avalon.Api.UnitTests/Controllers/ItemTemplateControllerShould.cs
+++ b/tests/Avalon.Api.UnitTests/Controllers/ItemTemplateControllerShould.cs
@@ -1,0 +1,74 @@
+using System.Security.Claims;
+using Avalon.Api.Authentication;
+using Avalon.Api.Contract;
+using Avalon.Api.Controllers;
+using Avalon.Common.ValueObjects;
+using Avalon.Database;
+using Avalon.Database.World.Repositories;
+using Avalon.Domain.World;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using Xunit;
+
+namespace Avalon.Api.UnitTests.Controllers;
+
+public class ItemTemplateControllerShould
+{
+    private readonly IItemTemplateRepository _repository = Substitute.For<IItemTemplateRepository>();
+
+    private ItemTemplateController MakeSut(ClaimsPrincipal user) =>
+        new(_repository)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext { User = user }
+            }
+        };
+
+    private static ClaimsPrincipal User(long accountId, params string[] roles)
+    {
+        var claims = new List<Claim> { new(ClaimTypes.NameIdentifier, accountId.ToString()) };
+        claims.AddRange(roles.Select(r => new Claim(ClaimTypes.Role, r)));
+        return new(new ClaimsIdentity(claims, "test", ClaimTypes.NameIdentifier, ClaimTypes.Role));
+    }
+
+    [Fact]
+    public async Task List_ReturnsPage()
+    {
+        _repository
+            .PaginateAsync(Arg.Any<EntityPaginateFilter<ItemTemplate>>(), false, Arg.Any<CancellationToken>())
+            .Returns(new PagedResult<ItemTemplate>(1, 50, 0, new List<ItemTemplate>()));
+
+        var sut = MakeSut(User(7, AvalonRoles.Player));
+        var result = await sut.List(1, 50, CancellationToken.None);
+
+        Assert.Equal(0, result.TotalCount);
+    }
+
+    [Fact]
+    public async Task Get_Returns404_WhenMissing()
+    {
+        _repository
+            .FindByIdAsync(Arg.Any<ItemTemplateId>(), false, Arg.Any<CancellationToken>())
+            .Returns((ItemTemplate?)null);
+
+        var sut = MakeSut(User(7, AvalonRoles.Player));
+        var result = await sut.Get(1, CancellationToken.None);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task Get_Returns200_WhenFound()
+    {
+        _repository
+            .FindByIdAsync(Arg.Any<ItemTemplateId>(), false, Arg.Any<CancellationToken>())
+            .Returns(new ItemTemplate { Id = new ItemTemplateId(1), Name = "Sword" });
+
+        var sut = MakeSut(User(7, AvalonRoles.Player));
+        var result = await sut.Get(1, CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+}

--- a/tests/Avalon.Api.UnitTests/Controllers/MapTemplateControllerShould.cs
+++ b/tests/Avalon.Api.UnitTests/Controllers/MapTemplateControllerShould.cs
@@ -1,0 +1,73 @@
+using System.Security.Claims;
+using Avalon.Api.Authentication;
+using Avalon.Api.Controllers;
+using Avalon.Common.ValueObjects;
+using Avalon.Database;
+using Avalon.Database.World.Repositories;
+using Avalon.Domain.World;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using Xunit;
+
+namespace Avalon.Api.UnitTests.Controllers;
+
+public class MapTemplateControllerShould
+{
+    private readonly IMapTemplateRepository _repository = Substitute.For<IMapTemplateRepository>();
+
+    private MapTemplateController MakeSut(ClaimsPrincipal user) =>
+        new(_repository)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext { User = user }
+            }
+        };
+
+    private static ClaimsPrincipal User(long accountId, params string[] roles)
+    {
+        var claims = new List<Claim> { new(ClaimTypes.NameIdentifier, accountId.ToString()) };
+        claims.AddRange(roles.Select(r => new Claim(ClaimTypes.Role, r)));
+        return new(new ClaimsIdentity(claims, "test", ClaimTypes.NameIdentifier, ClaimTypes.Role));
+    }
+
+    [Fact]
+    public async Task List_ReturnsPage()
+    {
+        _repository
+            .PaginateAsync(Arg.Any<EntityPaginateFilter<MapTemplate>>(), false, Arg.Any<CancellationToken>())
+            .Returns(new PagedResult<MapTemplate>(1, 50, 0, new List<MapTemplate>()));
+
+        var sut = MakeSut(User(7, AvalonRoles.Player));
+        var result = await sut.List(1, 50, CancellationToken.None);
+
+        Assert.Equal(0, result.TotalCount);
+    }
+
+    [Fact]
+    public async Task Get_Returns404_WhenMissing()
+    {
+        _repository
+            .FindByIdAsync(Arg.Any<MapTemplateId>(), false, Arg.Any<CancellationToken>())
+            .Returns((MapTemplate?)null);
+
+        var sut = MakeSut(User(7, AvalonRoles.Player));
+        var result = await sut.Get(1, CancellationToken.None);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task Get_Returns200_WhenFound()
+    {
+        _repository
+            .FindByIdAsync(Arg.Any<MapTemplateId>(), false, Arg.Any<CancellationToken>())
+            .Returns(new MapTemplate { Id = new MapTemplateId(1), Name = "Stormwind", Description = "", Directory = "" });
+
+        var sut = MakeSut(User(7, AvalonRoles.Player));
+        var result = await sut.Get(1, CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+}

--- a/tests/Avalon.Api.UnitTests/Controllers/SpellTemplateControllerShould.cs
+++ b/tests/Avalon.Api.UnitTests/Controllers/SpellTemplateControllerShould.cs
@@ -1,0 +1,73 @@
+using System.Security.Claims;
+using Avalon.Api.Authentication;
+using Avalon.Api.Controllers;
+using Avalon.Common.ValueObjects;
+using Avalon.Database;
+using Avalon.Database.World.Repositories;
+using Avalon.Domain.World;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using Xunit;
+
+namespace Avalon.Api.UnitTests.Controllers;
+
+public class SpellTemplateControllerShould
+{
+    private readonly ISpellTemplateRepository _repository = Substitute.For<ISpellTemplateRepository>();
+
+    private SpellTemplateController MakeSut(ClaimsPrincipal user) =>
+        new(_repository)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext { User = user }
+            }
+        };
+
+    private static ClaimsPrincipal User(long accountId, params string[] roles)
+    {
+        var claims = new List<Claim> { new(ClaimTypes.NameIdentifier, accountId.ToString()) };
+        claims.AddRange(roles.Select(r => new Claim(ClaimTypes.Role, r)));
+        return new(new ClaimsIdentity(claims, "test", ClaimTypes.NameIdentifier, ClaimTypes.Role));
+    }
+
+    [Fact]
+    public async Task List_ReturnsPage()
+    {
+        _repository
+            .PaginateAsync(Arg.Any<EntityPaginateFilter<SpellTemplate>>(), false, Arg.Any<CancellationToken>())
+            .Returns(new PagedResult<SpellTemplate>(1, 50, 0, new List<SpellTemplate>()));
+
+        var sut = MakeSut(User(7, AvalonRoles.Player));
+        var result = await sut.List(1, 50, CancellationToken.None);
+
+        Assert.Equal(0, result.TotalCount);
+    }
+
+    [Fact]
+    public async Task Get_Returns404_WhenMissing()
+    {
+        _repository
+            .FindByIdAsync(Arg.Any<SpellId>(), false, Arg.Any<CancellationToken>())
+            .Returns((SpellTemplate?)null);
+
+        var sut = MakeSut(User(7, AvalonRoles.Player));
+        var result = await sut.Get(1, CancellationToken.None);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task Get_Returns200_WhenFound()
+    {
+        _repository
+            .FindByIdAsync(Arg.Any<SpellId>(), false, Arg.Any<CancellationToken>())
+            .Returns(new SpellTemplate { Id = new SpellId(1), Name = "Fireball", SpellScript = "fireball.cs" });
+
+        var sut = MakeSut(User(7, AvalonRoles.Player));
+        var result = await sut.Get(1, CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+}

--- a/tests/Avalon.Api.UnitTests/Controllers/WorldControllerShould.cs
+++ b/tests/Avalon.Api.UnitTests/Controllers/WorldControllerShould.cs
@@ -1,0 +1,105 @@
+using System.Security.Claims;
+using Avalon.Api.Authentication;
+using Avalon.Api.Contract;
+using Avalon.Api.Controllers;
+using Avalon.Api.Services;
+using Avalon.Database;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using Xunit;
+
+namespace Avalon.Api.UnitTests.Controllers;
+
+public class WorldControllerShould
+{
+    private readonly IWorldService _service = Substitute.For<IWorldService>();
+
+    private WorldController MakeSut(ClaimsPrincipal user) =>
+        new(_service)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext { User = user }
+            }
+        };
+
+    private static ClaimsPrincipal User(long accountId, params string[] roles)
+    {
+        var claims = new List<Claim> { new(ClaimTypes.NameIdentifier, accountId.ToString()) };
+        claims.AddRange(roles.Select(r => new Claim(ClaimTypes.Role, r)));
+        return new(new ClaimsIdentity(claims, "test", ClaimTypes.NameIdentifier, ClaimTypes.Role));
+    }
+
+    [Fact]
+    public async Task List_ReturnsPage()
+    {
+        _service.ListAsync(1, 50, Arg.Any<CancellationToken>())
+            .Returns(new PagedResult<WorldDto>(1, 50, 0, new List<WorldDto>()));
+
+        var sut = MakeSut(User(7, AvalonRoles.Player));
+        var result = await sut.List(1, 50, CancellationToken.None);
+
+        Assert.Equal(0, result.TotalCount);
+    }
+
+    [Fact]
+    public async Task Get_Returns404_WhenMissing()
+    {
+        _service.GetAsync((ushort)1, Arg.Any<CancellationToken>()).Returns((WorldDto?)null);
+
+        var sut = MakeSut(User(7, AvalonRoles.Player));
+        var result = await sut.Get(1, CancellationToken.None);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task Get_Returns200_WhenFound()
+    {
+        _service.GetAsync((ushort)1, Arg.Any<CancellationToken>())
+            .Returns(new WorldDto { Id = 1, Name = "n" });
+
+        var sut = MakeSut(User(7, AvalonRoles.Player));
+        var result = await sut.Get(1, CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task Create_ReturnsCreated()
+    {
+        var request = new CreateWorldRequest { Name = "x", Host = "h", Port = 1, MinVersion = "0", Version = "0" };
+        _service.CreateAsync(request, Arg.Any<CancellationToken>())
+            .Returns(new WorldDto { Id = 42, Name = "x" });
+
+        var sut = MakeSut(User(99, AvalonRoles.Admin));
+        var result = await sut.Create(request, CancellationToken.None);
+
+        Assert.IsType<CreatedAtActionResult>(result);
+    }
+
+    [Fact]
+    public async Task Update_Returns404_WhenMissing()
+    {
+        _service.UpdateAsync((ushort)1, Arg.Any<UpdateWorldRequest>(), Arg.Any<CancellationToken>())
+            .Returns((WorldDto?)null);
+
+        var sut = MakeSut(User(99, AvalonRoles.Admin));
+        var result = await sut.Update(1, new UpdateWorldRequest(), CancellationToken.None);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task Update_Returns200_WhenUpdated()
+    {
+        _service.UpdateAsync((ushort)1, Arg.Any<UpdateWorldRequest>(), Arg.Any<CancellationToken>())
+            .Returns(new WorldDto { Id = 1, Name = "updated" });
+
+        var sut = MakeSut(User(99, AvalonRoles.Admin));
+        var result = await sut.Update(1, new UpdateWorldRequest { Name = "updated" }, CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result);
+    }
+}


### PR DESCRIPTION
## Summary

Stacked on top of #192. Expands the API surface with the following endpoints:

- **CharacterController**
  - `PATCH /character/{id}` — Admin+ full update; Player owner limited to cosmetic fields (name).
  - `GET /character/{id}/inventory` — inherits ownership via `ReadRequirement`.
  - `GET /character/paginate` — GameMaster+.
- **AccountController**
  - `POST /account/password` — self, BCrypt verify-then-rotate salt.
  - `POST /account/email/change` + `POST /account/email/confirm` — initiate stores `(accountId, newEmail)` in Redis under `auth:emailChange:{token}` (TTL 15 min). Confirm is anonymous with token. Token intentionally NOT returned to caller (email side-channel TODO).
  - `PATCH /account/{id}/status` — Admin+. On `Banned`/`Deactivated`, publishes account id to `world:accounts:disconnect` Redis channel.
  - `PATCH /account/{id}/roles` — Console only.
- **WorldController** — `/world` list/get (Player+), admin create/patch (Admin+).
- **Read-only template controllers** — Item / Spell / Creature / Map. Paginated, Player+.

## Details

- `Account.Salt`, `Account.Verifier`, `Account.Email` flipped from `init` to `set` to allow tracked-entity mutation.
- New `AccountStatus` enum (`Active`/`Banned`/`Deactivated`) + `AddAccountStatus` EF migration.
- `ISecureRandom` DI registration added to Api (was only registered in Auth server).
- Template controllers use existing `I{Entity}TemplateRepository` pre-registered via `AddWorldDatabase`. No new DI wiring needed.
- Scalar primitives on all DTOs (no `ValueObject<T>` leaks); controllers convert at route boundary.
- `PaginatedResult<T>` reused via `PagedResultExtensions.MapTo`.

## Test plan

- [x] 527 unit tests passing (32 new: Character 6, Account 6, World 6, Templates 12, plus 2 pre-existing fixtures).
- [x] Build clean.
- [ ] Smoke test new migration applies without data loss.
- [ ] Verify Redis publish on ban works against a local `docker compose` redis.
- [ ] Manual test PATCH roles end-to-end against Console-gated policy.

## Notes

Depends on #192 for `ReadRequirement` / `WriteRequirement` / `HasRoleAtLeast` / `NotFoundOrForbid`. Merge #192 first, then rebase this PR onto main.