### PR TITLE
feat(api): personal access tokens — PAT auth scheme + /pat controller

### DIFF
--- a/src/Server/Avalon.Api/Authentication/AV/AvalonAuthenticationHandler.cs
+++ b/src/Server/Avalon.Api/Authentication/AV/AvalonAuthenticationHandler.cs
@@ -1,5 +1,7 @@
 using System.Security.Claims;
 using System.Text.Encodings.Web;
+using Avalon.Api.Services;
+using Avalon.Domain.Auth;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Options;
 using Microsoft.Net.Http.Headers;
@@ -8,40 +10,61 @@ namespace Avalon.Api.Authentication.AV;
 
 public class AvalonAuthenticationHandler : AuthenticationHandler<AvalonAuthenticationSchemeOptions>
 {
-    [Obsolete("ISystemClock is obsolete, use TimeProvider on AuthenticationSchemeOptions instead.")]
-    public AvalonAuthenticationHandler(IOptionsMonitor<AvalonAuthenticationSchemeOptions> options, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock)
-        : base(options, logger, encoder, clock) { }
+    private readonly IPersonalAccessTokenService _pats;
+    private readonly IAccountService _accounts;
+    private const string Prefix = "avp_";
+    private const int ExpectedLength = 47;
 
-    public AvalonAuthenticationHandler(IOptionsMonitor<AvalonAuthenticationSchemeOptions> options, ILoggerFactory logger, UrlEncoder encoder)
-        : base(options, logger, encoder) { }
+    public AvalonAuthenticationHandler(
+        IOptionsMonitor<AvalonAuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder,
+        IPersonalAccessTokenService pats,
+        IAccountService accounts)
+        : base(options, logger, encoder)
+    {
+        _pats = pats;
+        _accounts = accounts;
+    }
 
     protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
     {
         if (!Request.Headers.TryGetValue(HeaderNames.Authorization, out var value))
+            return AuthenticateResult.NoResult();
+
+        var parts = value.ToString().Split(' ', 2);
+        if (parts.Length != 2 || !string.Equals(parts[0], "Avalon", StringComparison.OrdinalIgnoreCase))
+            return AuthenticateResult.NoResult();
+
+        var token = parts[1];
+        if (!token.StartsWith(Prefix, StringComparison.Ordinal) || token.Length != ExpectedLength)
+            return AuthenticateResult.Fail("invalid token format");
+
+        var pat = await _pats.FindByRawTokenAsync(token, Context.RequestAborted);
+        if (pat is null) return AuthenticateResult.Fail("invalid token");
+        if (pat.RevokedAt is not null) return AuthenticateResult.Fail("token revoked");
+        if (pat.ExpiresAt is { } exp && exp < DateTime.UtcNow) return AuthenticateResult.Fail("token expired");
+
+        var account = await _accounts.FindByIdAsync(pat.AccountId, Context.RequestAborted);
+        if (account is null) return AuthenticateResult.Fail("account not found");
+        if (account.Status != AccountStatus.Active) return AuthenticateResult.Fail("account inactive");
+
+        var claims = new List<Claim>
         {
-            return await Task.FromResult(AuthenticateResult.Fail("Header Not Found."));
-        }
-
-        if (Context.User.Identity?.IsAuthenticated ?? false) return AuthenticateResult.NoResult();
-
-        var header = value.ToString();
-        var segments = header.Split(' ');
-        if (segments.Length != 2) return AuthenticateResult.NoResult();
-        if (segments[0].ToLowerInvariant() != "avalon") return AuthenticateResult.NoResult();
-        var token = segments[1];
-        if (string.IsNullOrWhiteSpace(token)) return AuthenticateResult.Fail("Invalid bearer token");
-
-        // TODO: validate token
-
-        var claims = new[] {
-            new Claim("test", "value"),
+            new(ClaimTypes.NameIdentifier, account.Id.Value.ToString()),
+            new(ClaimTypes.Name, account.Username),
+            new(ClaimTypes.Email, account.Email),
+            new("pat_id", pat.Id.Value.ToString()),
         };
+        foreach (AccountAccessLevel flag in Enum.GetValues<AccountAccessLevel>())
+            if (flag != 0 && pat.Roles.HasFlag(flag))
+                claims.Add(new Claim(ClaimTypes.GroupSid, flag.ToString()));
 
-        var identity = new ClaimsIdentity(claims, Scheme.Name);
+        // Fire-and-forget write-coalesced last-used update — don't block the request.
+        _ = _pats.TouchLastUsedAsync(pat.Id, CancellationToken.None);
+
+        var identity = new ClaimsIdentity(claims, Scheme.Name, ClaimTypes.NameIdentifier, ClaimTypes.GroupSid);
         var principal = new ClaimsPrincipal(identity);
-        var ticket = new AuthenticationTicket(principal, Scheme.Name);
-
-        return AuthenticateResult.Success(ticket);
-
+        return AuthenticateResult.Success(new AuthenticationTicket(principal, Scheme.Name));
     }
 }

--- a/src/Server/Avalon.Api/Authorization/PatReadHandler.cs
+++ b/src/Server/Avalon.Api/Authorization/PatReadHandler.cs
@@ -1,0 +1,23 @@
+using Avalon.Api.Authentication;
+using Avalon.Domain.Auth;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Avalon.Api.Authorization;
+
+public sealed class PatReadHandler : AuthorizationHandler<ReadRequirement, PersonalAccessToken>
+{
+    protected override Task HandleRequirementAsync(
+        AuthorizationHandlerContext context, ReadRequirement requirement, PersonalAccessToken resource)
+    {
+        if (context.User.HasRoleAtLeast(AvalonRoles.Admin))
+        {
+            context.Succeed(requirement);
+            return Task.CompletedTask;
+        }
+
+        if (resource.AccountId == context.User.AccountId())
+            context.Succeed(requirement);
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Server/Avalon.Api/Authorization/PatWriteHandler.cs
+++ b/src/Server/Avalon.Api/Authorization/PatWriteHandler.cs
@@ -1,0 +1,23 @@
+using Avalon.Api.Authentication;
+using Avalon.Domain.Auth;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Avalon.Api.Authorization;
+
+public sealed class PatWriteHandler : AuthorizationHandler<WriteRequirement, PersonalAccessToken>
+{
+    protected override Task HandleRequirementAsync(
+        AuthorizationHandlerContext context, WriteRequirement requirement, PersonalAccessToken resource)
+    {
+        if (context.User.HasRoleAtLeast(AvalonRoles.Admin))
+        {
+            context.Succeed(requirement);
+            return Task.CompletedTask;
+        }
+
+        if (resource.AccountId == context.User.AccountId())
+            context.Succeed(requirement);
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Server/Avalon.Api/Contract/CreateAdminPatRequest.cs
+++ b/src/Server/Avalon.Api/Contract/CreateAdminPatRequest.cs
@@ -1,0 +1,9 @@
+using Avalon.Domain.Auth;
+namespace Avalon.Api.Contract;
+public sealed class CreateAdminPatRequest
+{
+    public long AccountId { get; set; }
+    public string Name { get; set; } = "";
+    public DateTime? ExpiresAt { get; set; }
+    public AccountAccessLevel Roles { get; set; }
+}

--- a/src/Server/Avalon.Api/Contract/CreatePatRequest.cs
+++ b/src/Server/Avalon.Api/Contract/CreatePatRequest.cs
@@ -1,0 +1,8 @@
+using Avalon.Domain.Auth;
+namespace Avalon.Api.Contract;
+public sealed class CreatePatRequest
+{
+    public string Name { get; set; } = "";
+    public DateTime? ExpiresAt { get; set; }
+    public AccountAccessLevel? Roles { get; set; }
+}

--- a/src/Server/Avalon.Api/Contract/PatCreatedDto.cs
+++ b/src/Server/Avalon.Api/Contract/PatCreatedDto.cs
@@ -1,0 +1,5 @@
+namespace Avalon.Api.Contract;
+public sealed class PatCreatedDto : PatDto
+{
+    public string Token { get; set; } = "";
+}

--- a/src/Server/Avalon.Api/Contract/PatDto.cs
+++ b/src/Server/Avalon.Api/Contract/PatDto.cs
@@ -1,0 +1,14 @@
+using Avalon.Domain.Auth;
+namespace Avalon.Api.Contract;
+public class PatDto
+{
+    public uint Id { get; set; }
+    public long AccountId { get; set; }
+    public string Name { get; set; } = "";
+    public string Prefix { get; set; } = "";
+    public AccountAccessLevel Roles { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime? ExpiresAt { get; set; }
+    public DateTime? LastUsedAt { get; set; }
+    public DateTime? RevokedAt { get; set; }
+}

--- a/src/Server/Avalon.Api/Controllers/AccountController.cs
+++ b/src/Server/Avalon.Api/Controllers/AccountController.cs
@@ -112,7 +112,7 @@ public class AccountController : BaseController
         [FromBody] AccountStatusPatchRequest req,
         CancellationToken ct)
     {
-        await _accountService.UpdateStatusAsync(new AccountId(id), req.State, req.Reason, ct);
+        await _accountService.UpdateStatusAsync(new AccountId(id), req.State, req.Reason, User.AccountId(), ct);
         return NoContent();
     }
 

--- a/src/Server/Avalon.Api/Controllers/PersonalAccessTokenController.cs
+++ b/src/Server/Avalon.Api/Controllers/PersonalAccessTokenController.cs
@@ -1,0 +1,165 @@
+using System.Security.Claims;
+using Avalon.Api.Authentication;
+using Avalon.Api.Authorization;
+using Avalon.Api.Contract;
+using Avalon.Api.Services;
+using Avalon.Common.ValueObjects;
+using Avalon.Domain.Auth;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Avalon.Api.Controllers;
+
+[ApiController]
+[Authorize(Policy = AvalonRoles.Player)]
+[Route("pat")]
+public class PersonalAccessTokenController : BaseController
+{
+    private readonly IPersonalAccessTokenService _service;
+    private readonly IAuthorizationService _authz;
+
+    public PersonalAccessTokenController(IPersonalAccessTokenService service, IAuthorizationService authz)
+    {
+        _service = service;
+        _authz = authz;
+    }
+
+    private bool CallerIsPat => User.HasClaim(c => c.Type == "pat_id");
+
+    private static PatDto ToDto(PersonalAccessToken p) => new()
+    {
+        Id = p.Id.Value,
+        AccountId = p.AccountId.Value,
+        Name = p.Name,
+        Prefix = p.TokenPrefix,
+        Roles = p.Roles,
+        CreatedAt = p.CreatedAt,
+        ExpiresAt = p.ExpiresAt,
+        LastUsedAt = p.LastUsedAt,
+        RevokedAt = p.RevokedAt,
+    };
+
+    private static AccountAccessLevel CollectRoles(ClaimsPrincipal user)
+    {
+        var roles = (AccountAccessLevel)0;
+        foreach (AccountAccessLevel flag in Enum.GetValues<AccountAccessLevel>())
+            if (flag != 0 && user.IsInRole(flag.ToString())) roles |= flag;
+        return roles;
+    }
+
+    // ---------------- Self-service ----------------
+
+    [HttpPost]
+    [ProducesResponseType(typeof(PatCreatedDto), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> Create([FromBody] CreatePatRequest req, CancellationToken ct)
+    {
+        if (CallerIsPat)
+            return StatusCode(StatusCodes.Status403Forbidden, "PAT cannot mint new PATs");
+
+        var result = await _service.MintSelfAsync(
+            callerId: User.AccountId(),
+            callerRoles: CollectRoles(User),
+            name: req.Name,
+            expiresAt: req.ExpiresAt,
+            requestedRoles: req.Roles,
+            ct);
+
+        return CreatedAtAction(nameof(GetById), new { id = result.Id.Value }, new PatCreatedDto
+        {
+            Id = result.Id.Value,
+            AccountId = User.AccountId().Value,
+            Name = result.Name,
+            Prefix = result.Prefix,
+            Roles = result.Roles,
+            CreatedAt = DateTime.UtcNow,
+            ExpiresAt = result.ExpiresAt,
+            Token = result.Token,
+        });
+    }
+
+    [HttpGet]
+    public async Task<IList<PatDto>> List(CancellationToken ct)
+    {
+        var list = await _service.ListByAccountAsync(User.AccountId(), includeRevoked: true, ct);
+        return list.Select(ToDto).ToList();
+    }
+
+    [HttpGet("{id:long}")]
+    [ProducesResponseType(typeof(PatDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetById([FromRoute] uint id, CancellationToken ct)
+    {
+        var pat = await _service.GetAsync(new PersonalAccessTokenId(id), ct);
+        if (pat is null) return NotFound();
+
+        var authz = await _authz.AuthorizeAsync(User, pat, new ReadRequirement());
+        if (!authz.Succeeded) return NotFoundOrForbid();
+
+        return Ok(ToDto(pat));
+    }
+
+    [HttpDelete("{id:long}")]
+    public async Task<IActionResult> Revoke([FromRoute] uint id, CancellationToken ct)
+    {
+        var pat = await _service.GetAsync(new PersonalAccessTokenId(id), ct);
+        if (pat is null) return NotFound();
+
+        var authz = await _authz.AuthorizeAsync(User, pat, new WriteRequirement());
+        if (!authz.Succeeded) return NotFoundOrForbid();
+
+        await _service.RevokeAsync(pat, User.AccountId(), ct);
+        return NoContent();
+    }
+
+    // ---------------- Admin ----------------
+
+    [HttpPost("admin")]
+    [Authorize(Policy = AvalonRoles.Admin)]
+    [ProducesResponseType(typeof(PatCreatedDto), StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> CreateAdmin([FromBody] CreateAdminPatRequest req, CancellationToken ct)
+    {
+        if (CallerIsPat)
+            return StatusCode(StatusCodes.Status403Forbidden, "PAT cannot mint new PATs");
+
+        var result = await _service.MintAdminAsync(
+            callerRoles: CollectRoles(User),
+            targetAccountId: new AccountId(req.AccountId),
+            name: req.Name,
+            expiresAt: req.ExpiresAt,
+            requestedRoles: req.Roles,
+            ct);
+
+        return CreatedAtAction(nameof(GetById), new { id = result.Id.Value }, new PatCreatedDto
+        {
+            Id = result.Id.Value,
+            AccountId = req.AccountId,
+            Name = result.Name,
+            Prefix = result.Prefix,
+            Roles = result.Roles,
+            CreatedAt = DateTime.UtcNow,
+            ExpiresAt = result.ExpiresAt,
+            Token = result.Token,
+        });
+    }
+
+    [HttpGet("admin")]
+    [Authorize(Policy = AvalonRoles.Admin)]
+    public async Task<IList<PatDto>> ListAdmin(
+        [FromQuery] long accountId,
+        [FromQuery] bool includeRevoked = false,
+        CancellationToken ct = default)
+    {
+        var list = await _service.ListByAccountAsync(new AccountId(accountId), includeRevoked, ct);
+        return list.Select(ToDto).ToList();
+    }
+
+    [HttpDelete("admin/account/{accountId:long}")]
+    [Authorize(Policy = AvalonRoles.Admin)]
+    public async Task<IActionResult> RevokeAllForAccount([FromRoute] long accountId, CancellationToken ct)
+    {
+        var count = await _service.RevokeAllForAccountAsync(new AccountId(accountId), User.AccountId(), ct);
+        return Ok(new { revoked = count });
+    }
+}

--- a/src/Server/Avalon.Api/ServiceRegistration.cs
+++ b/src/Server/Avalon.Api/ServiceRegistration.cs
@@ -129,5 +129,7 @@ public static class ServiceRegistration
         services.AddScoped<IAuthorizationHandler, Authorization.CharacterWriteHandler>();
         services.AddScoped<IAuthorizationHandler, Authorization.AccountReadHandler>();
         services.AddScoped<IAuthorizationHandler, Authorization.AccountWriteHandler>();
+        services.AddScoped<IAuthorizationHandler, Authorization.PatReadHandler>();
+        services.AddScoped<IAuthorizationHandler, Authorization.PatWriteHandler>();
     }
 }

--- a/src/Server/Avalon.Api/ServiceRegistration.cs
+++ b/src/Server/Avalon.Api/ServiceRegistration.cs
@@ -34,6 +34,8 @@ public static class ServiceRegistration
         services.AddScoped<IAccountService, AccountService>();
         services.AddScoped<ICharacterService, CharacterService>();
         services.AddScoped<IWorldService, WorldService>();
+        services.AddScoped<IPersonalAccessTokenService, PersonalAccessTokenService>();
+        services.AddSingleton(TimeProvider.System);
         services.AddMfaService();
         services.AddSecureRandom();
         services.AddSingleton<IReplicatedCache, ReplicatedCache>();

--- a/src/Server/Avalon.Api/Services/AccountService.cs
+++ b/src/Server/Avalon.Api/Services/AccountService.cs
@@ -6,6 +6,7 @@ using Avalon.Api.Contract;
 using Avalon.Api.Exceptions;
 using Avalon.Common.ValueObjects;
 using Avalon.Database;
+using Avalon.Database.Auth;
 using Avalon.Database.Auth.Repositories;
 using Avalon.Domain.Auth;
 using Avalon.Infrastructure;
@@ -25,7 +26,7 @@ public interface IAccountService
     Task ChangePasswordAsync(AccountId accountId, string currentPassword, string newPassword, CancellationToken cancellationToken = default);
     Task<string> InitiateEmailChangeAsync(AccountId accountId, string newEmail, CancellationToken cancellationToken = default);
     Task ConfirmEmailChangeAsync(string token, CancellationToken cancellationToken = default);
-    Task UpdateStatusAsync(AccountId accountId, AccountStatus state, string? reason, CancellationToken cancellationToken = default);
+    Task UpdateStatusAsync(AccountId accountId, AccountStatus state, string? reason, AccountId actorId, CancellationToken cancellationToken = default);
     Task UpdateRolesAsync(AccountId accountId, AccountAccessLevel roles, CancellationToken cancellationToken = default);
 }
 
@@ -39,6 +40,8 @@ public class AccountService : IAccountService
     private readonly IDeviceRepository _deviceRepository;
     private readonly IReplicatedCache _cache;
     private readonly ISecureRandom _secureRandom;
+    private readonly IPersonalAccessTokenService _patService;
+    private readonly AuthDbContext _authDbContext;
     public AccountService(ILoggerFactory loggerFactory,
         IAccountRepository accountRepository,
         IJwtUtils jwtUtils,
@@ -46,7 +49,9 @@ public class AccountService : IAccountService
         IMfaSetupRepository mfaSetupRepository,
         IDeviceRepository deviceRepository,
         IReplicatedCache cache,
-        ISecureRandom secureRandom)
+        ISecureRandom secureRandom,
+        IPersonalAccessTokenService patService,
+        AuthDbContext authDbContext)
     {
         _logger = loggerFactory.CreateLogger<AccountService>();
         _accountRepository = accountRepository;
@@ -56,6 +61,8 @@ public class AccountService : IAccountService
         _deviceRepository = deviceRepository;
         _cache = cache;
         _secureRandom = secureRandom;
+        _patService = patService;
+        _authDbContext = authDbContext;
     }
 
     public async Task<Account?> FindByIdAsync(AccountId id, CancellationToken cancellationToken = default)
@@ -221,15 +228,31 @@ public class AccountService : IAccountService
 
     // NOTE: `reason` is currently accepted but not persisted (future: audit log).
     public async Task UpdateStatusAsync(AccountId accountId, AccountStatus state, string? reason,
-        CancellationToken cancellationToken = default)
+        AccountId actorId, CancellationToken cancellationToken = default)
     {
-        var account = await _accountRepository.FindByIdAsync(accountId, track: true, cancellationToken)
-            ?? throw new BusinessException("Account not found");
+        await using var transaction = await _authDbContext.Database.BeginTransactionAsync(cancellationToken);
+        try
+        {
+            var account = await _accountRepository.FindByIdAsync(accountId, track: true, cancellationToken)
+                ?? throw new BusinessException("Account not found");
 
-        account.Status = state;
-        await _accountRepository.UpdateAsync(account, cancellationToken);
+            account.Status = state;
+            await _accountRepository.UpdateAsync(account, cancellationToken);
 
-        if (state == AccountStatus.Banned || state == AccountStatus.Deactivated)
+            if (state is AccountStatus.Banned or AccountStatus.Deactivated)
+            {
+                await _patService.RevokeAllForAccountAsync(accountId, actorId, cancellationToken);
+            }
+
+            await transaction.CommitAsync(cancellationToken);
+        }
+        catch
+        {
+            await transaction.RollbackAsync(cancellationToken);
+            throw;
+        }
+
+        if (state is AccountStatus.Banned or AccountStatus.Deactivated)
         {
             await _cache.PublishAsync(CacheKeys.WorldAccountsDisconnectChannel, accountId.Value.ToString());
         }

--- a/src/Server/Avalon.Api/Services/PersonalAccessTokenService.cs
+++ b/src/Server/Avalon.Api/Services/PersonalAccessTokenService.cs
@@ -1,0 +1,158 @@
+using System.Security.Cryptography;
+using System.Text;
+using Avalon.Api.Exceptions;
+using Avalon.Common.ValueObjects;
+using Avalon.Database.Auth.Repositories;
+using Avalon.Domain.Auth;
+using Avalon.Infrastructure.Services;
+
+namespace Avalon.Api.Services;
+
+public interface IPersonalAccessTokenService
+{
+    Task<MintResult> MintSelfAsync(AccountId callerId, AccountAccessLevel callerRoles, string name,
+        DateTime? expiresAt, AccountAccessLevel? requestedRoles, CancellationToken cancellationToken = default);
+
+    Task<MintResult> MintAdminAsync(AccountAccessLevel callerRoles, AccountId targetAccountId, string name,
+        DateTime? expiresAt, AccountAccessLevel requestedRoles, CancellationToken cancellationToken = default);
+
+    Task<PersonalAccessToken?> GetAsync(PersonalAccessTokenId id, CancellationToken cancellationToken = default);
+    Task<List<PersonalAccessToken>> ListByAccountAsync(AccountId accountId, bool includeRevoked, CancellationToken cancellationToken = default);
+    Task<PersonalAccessToken?> FindByRawTokenAsync(string token, CancellationToken cancellationToken = default);
+    Task RevokeAsync(PersonalAccessToken token, AccountId revokedBy, CancellationToken cancellationToken = default);
+    Task<int> RevokeAllForAccountAsync(AccountId accountId, AccountId revokedBy, CancellationToken cancellationToken = default);
+    Task TouchLastUsedAsync(PersonalAccessTokenId id, CancellationToken cancellationToken = default);
+}
+
+public sealed record MintResult(
+    PersonalAccessTokenId Id,
+    string Name,
+    string Token,
+    string Prefix,
+    DateTime? ExpiresAt,
+    AccountAccessLevel Roles);
+
+public class PersonalAccessTokenService : IPersonalAccessTokenService
+{
+    public static readonly TimeSpan MaxLifetime = TimeSpan.FromDays(365);
+    public static readonly TimeSpan DefaultLifetime = TimeSpan.FromDays(365);
+    public const string TokenPrefix = "avp_";
+    public const int TokenPrefixDisplayLength = 8;
+    private static readonly TimeSpan LastUsedBucket = TimeSpan.FromSeconds(60);
+
+    private readonly IPersonalAccessTokenRepository _repository;
+    private readonly ISecureRandom _random;
+    private readonly TimeProvider _time;
+
+    public PersonalAccessTokenService(
+        IPersonalAccessTokenRepository repository,
+        ISecureRandom random,
+        TimeProvider time)
+    {
+        _repository = repository;
+        _random = random;
+        _time = time;
+    }
+
+    public Task<MintResult> MintSelfAsync(AccountId callerId, AccountAccessLevel callerRoles, string name,
+        DateTime? expiresAt, AccountAccessLevel? requestedRoles, CancellationToken cancellationToken = default)
+    {
+        var roles = requestedRoles ?? callerRoles;
+        return MintInternalAsync(callerId, callerRoles, roles, name, expiresAt, cancellationToken);
+    }
+
+    public Task<MintResult> MintAdminAsync(AccountAccessLevel callerRoles, AccountId targetAccountId, string name,
+        DateTime? expiresAt, AccountAccessLevel requestedRoles, CancellationToken cancellationToken = default)
+    {
+        return MintInternalAsync(targetAccountId, callerRoles, requestedRoles, name, expiresAt, cancellationToken);
+    }
+
+    private async Task<MintResult> MintInternalAsync(
+        AccountId accountId,
+        AccountAccessLevel callerRoles,
+        AccountAccessLevel roles,
+        string name,
+        DateTime? expiresAt,
+        CancellationToken cancellationToken)
+    {
+        if ((roles & ~callerRoles) != 0)
+        {
+            throw new BusinessException("Requested roles exceed caller roles");
+        }
+
+        var now = _time.GetUtcNow().UtcDateTime;
+
+        DateTime? resolvedExpiry;
+        if (expiresAt is null)
+        {
+            resolvedExpiry = now + DefaultLifetime;
+        }
+        else
+        {
+            if (expiresAt.Value > now + MaxLifetime)
+            {
+                throw new BusinessException("PAT lifetime exceeds maximum of 365 days");
+            }
+            resolvedExpiry = expiresAt;
+        }
+
+        var rawBytes = _random.GetBytes(32);
+        var base64Url = Convert.ToBase64String(rawBytes)
+            .Replace('+', '-')
+            .Replace('/', '_')
+            .TrimEnd('=');
+        var token = TokenPrefix + base64Url;
+
+        var tokenHash = SHA256.HashData(Encoding.UTF8.GetBytes(token));
+        var prefix = token[..TokenPrefixDisplayLength];
+
+        var entity = new PersonalAccessToken
+        {
+            AccountId = accountId,
+            Name = name,
+            TokenHash = tokenHash,
+            TokenPrefix = prefix,
+            Roles = roles,
+            CreatedAt = now,
+            ExpiresAt = resolvedExpiry,
+        };
+
+        var created = await _repository.CreateAsync(entity, cancellationToken);
+
+        return new MintResult(
+            created.Id,
+            created.Name,
+            token,
+            prefix,
+            created.ExpiresAt,
+            created.Roles);
+    }
+
+    public Task<PersonalAccessToken?> GetAsync(PersonalAccessTokenId id, CancellationToken cancellationToken = default) =>
+        _repository.FindByIdAsync(id, track: false, cancellationToken);
+
+    public Task<List<PersonalAccessToken>> ListByAccountAsync(AccountId accountId, bool includeRevoked, CancellationToken cancellationToken = default) =>
+        _repository.ListByAccountAsync(accountId, includeRevoked, cancellationToken);
+
+    public Task<PersonalAccessToken?> FindByRawTokenAsync(string token, CancellationToken cancellationToken = default)
+    {
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(token));
+        return _repository.FindByHashAsync(hash, cancellationToken);
+    }
+
+    public Task RevokeAsync(PersonalAccessToken token, AccountId revokedBy, CancellationToken cancellationToken = default)
+    {
+        token.RevokedAt = _time.GetUtcNow().UtcDateTime;
+        token.RevokedBy = revokedBy;
+        return _repository.UpdateAsync(token, cancellationToken);
+    }
+
+    public Task<int> RevokeAllForAccountAsync(AccountId accountId, AccountId revokedBy, CancellationToken cancellationToken = default) =>
+        _repository.RevokeAllForAccountAsync(accountId, revokedBy, cancellationToken);
+
+    public Task TouchLastUsedAsync(PersonalAccessTokenId id, CancellationToken cancellationToken = default)
+    {
+        var now = _time.GetUtcNow().UtcDateTime;
+        return _repository.UpdateLastUsedIfStaleAsync(id, now, LastUsedBucket, cancellationToken);
+    }
+}

--- a/src/Server/Avalon.Database.Auth/AuthDbContext.cs
+++ b/src/Server/Avalon.Database.Auth/AuthDbContext.cs
@@ -70,6 +70,7 @@ public class AuthDbContext(ILoggerFactory loggerFactory, IOptions<DatabaseConfig
     public DbSet<MFASetup> MfaSetups { get; set; } = null!;
     public DbSet<RefreshToken> RefreshTokens { get; set; } = null!;
     public DbSet<AvalonToken> Tokens { get; set; } = null!;
+    public DbSet<PersonalAccessToken> PersonalAccessTokens { get; set; } = null!;
     public DbSet<Domain.Auth.World> Worlds { get; set; } = null!;
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
@@ -87,6 +88,7 @@ public class AuthDbContext(ILoggerFactory loggerFactory, IOptions<DatabaseConfig
         Configure(modelBuilder.Entity<MFASetup>());
         Configure(modelBuilder.Entity<RefreshToken>());
         Configure(modelBuilder.Entity<AvalonToken>());
+        Configure(modelBuilder.Entity<PersonalAccessToken>());
         Configure(modelBuilder.Entity<Domain.Auth.World>());
     }
 
@@ -201,6 +203,36 @@ public class AuthDbContext(ILoggerFactory loggerFactory, IOptions<DatabaseConfig
         builder.HasOne(e => e.Account)
             .WithMany()
             .HasForeignKey(e => e.AccountId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+
+    private static void Configure(EntityTypeBuilder<PersonalAccessToken> builder)
+    {
+        builder.HasKey(b => b.Id);
+
+        builder.Property(b => b.Id)
+            .HasConversion(
+                v => v.Value,
+                v => new PersonalAccessTokenId(v)
+            ).IsRequired();
+
+        builder.Property(b => b.AccountId)
+            .HasConversion(
+                v => v.Value,
+                v => new AccountId(v)
+            ).IsRequired();
+
+        builder.Property(b => b.RevokedBy)
+            .HasConversion(
+                v => v!.Value,
+                v => new AccountId(v));
+
+        builder.HasIndex(b => b.TokenHash).IsUnique();
+        builder.HasIndex(b => new { b.AccountId, b.RevokedAt });
+
+        builder.HasOne<Account>()
+            .WithMany()
+            .HasForeignKey(b => b.AccountId)
             .OnDelete(DeleteBehavior.Cascade);
     }
 

--- a/src/Server/Avalon.Database.Auth/Extensions/ServiceExtensions.cs
+++ b/src/Server/Avalon.Database.Auth/Extensions/ServiceExtensions.cs
@@ -22,7 +22,8 @@ public static class ServiceExtensions
             .AddScoped<Repositories.IAccountRepository, Repositories.AccountRepository>()
             .AddScoped<Repositories.IMfaSetupRepository, Repositories.MfaSetupRepository>()
             .AddScoped<Repositories.IDeviceRepository, Repositories.DeviceRepository>()
-            .AddScoped<Repositories.IWorldRepository, Repositories.WorldRepository>();
+            .AddScoped<Repositories.IWorldRepository, Repositories.WorldRepository>()
+            .AddScoped<Repositories.IPersonalAccessTokenRepository, Repositories.PersonalAccessTokenRepository>();
 
         return services;
     }

--- a/src/Server/Avalon.Database.Auth/Migrations/20260422050712_AddPersonalAccessTokens.Designer.cs
+++ b/src/Server/Avalon.Database.Auth/Migrations/20260422050712_AddPersonalAccessTokens.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Avalon.Database.Auth;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Avalon.Database.Auth.Migrations
 {
     [DbContext(typeof(AuthDbContext))]
-    partial class AuthDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260422050712_AddPersonalAccessTokens")]
+    partial class AddPersonalAccessTokens
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Server/Avalon.Database.Auth/Migrations/20260422050712_AddPersonalAccessTokens.cs
+++ b/src/Server/Avalon.Database.Auth/Migrations/20260422050712_AddPersonalAccessTokens.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Avalon.Database.Auth.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPersonalAccessTokens : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PersonalAccessTokens",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    AccountId = table.Column<long>(type: "bigint", nullable: false),
+                    Name = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    TokenHash = table.Column<byte[]>(type: "bytea", nullable: false),
+                    TokenPrefix = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false),
+                    Roles = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ExpiresAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    LastUsedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    RevokedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    RevokedBy = table.Column<long>(type: "bigint", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PersonalAccessTokens", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_PersonalAccessTokens_Accounts_AccountId",
+                        column: x => x.AccountId,
+                        principalTable: "Accounts",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PersonalAccessTokens_AccountId_RevokedAt",
+                table: "PersonalAccessTokens",
+                columns: new[] { "AccountId", "RevokedAt" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PersonalAccessTokens_TokenHash",
+                table: "PersonalAccessTokens",
+                column: "TokenHash",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PersonalAccessTokens");
+        }
+    }
+}

--- a/src/Server/Avalon.Database.Auth/Repositories/PersonalAccessTokenRepository.cs
+++ b/src/Server/Avalon.Database.Auth/Repositories/PersonalAccessTokenRepository.cs
@@ -1,0 +1,61 @@
+using Avalon.Common.ValueObjects;
+using Avalon.Domain.Auth;
+using Microsoft.EntityFrameworkCore;
+
+namespace Avalon.Database.Auth.Repositories;
+
+public interface IPersonalAccessTokenRepository : IRepository<PersonalAccessToken, PersonalAccessTokenId>
+{
+    Task<PersonalAccessToken?> FindByHashAsync(byte[] hash, CancellationToken cancellationToken = default);
+    Task<List<PersonalAccessToken>> ListByAccountAsync(AccountId accountId, bool includeRevoked, CancellationToken cancellationToken = default);
+    Task<int> RevokeAllForAccountAsync(AccountId accountId, AccountId revokedBy, CancellationToken cancellationToken = default);
+    Task<bool> UpdateLastUsedIfStaleAsync(PersonalAccessTokenId id, DateTime now, TimeSpan minStale, CancellationToken cancellationToken = default);
+}
+
+public class PersonalAccessTokenRepository : EntityFrameworkRepository<PersonalAccessToken, PersonalAccessTokenId>, IPersonalAccessTokenRepository
+{
+    public PersonalAccessTokenRepository(AuthDbContext db)
+        : base(db)
+    { }
+
+    public Task<PersonalAccessToken?> FindByHashAsync(byte[] hash, CancellationToken cancellationToken = default)
+    {
+        return Context.Set<PersonalAccessToken>()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(p => p.TokenHash == hash, cancellationToken);
+    }
+
+    public Task<List<PersonalAccessToken>> ListByAccountAsync(AccountId accountId, bool includeRevoked, CancellationToken cancellationToken = default)
+    {
+        var query = Context.Set<PersonalAccessToken>()
+            .AsNoTracking()
+            .Where(p => p.AccountId == accountId);
+
+        if (!includeRevoked)
+        {
+            query = query.Where(p => p.RevokedAt == null);
+        }
+
+        return query.ToListAsync(cancellationToken);
+    }
+
+    public async Task<int> RevokeAllForAccountAsync(AccountId accountId, AccountId revokedBy, CancellationToken cancellationToken = default)
+    {
+        var now = DateTime.UtcNow;
+        return await Context.Set<PersonalAccessToken>()
+            .Where(p => p.AccountId == accountId && p.RevokedAt == null)
+            .ExecuteUpdateAsync(s => s
+                    .SetProperty(p => p.RevokedAt, now)
+                    .SetProperty(p => p.RevokedBy, revokedBy),
+                cancellationToken);
+    }
+
+    public async Task<bool> UpdateLastUsedIfStaleAsync(PersonalAccessTokenId id, DateTime now, TimeSpan minStale, CancellationToken cancellationToken = default)
+    {
+        var threshold = now - minStale;
+        var rows = await Context.Set<PersonalAccessToken>()
+            .Where(p => p.Id == id && (p.LastUsedAt == null || p.LastUsedAt < threshold))
+            .ExecuteUpdateAsync(s => s.SetProperty(p => p.LastUsedAt, now), cancellationToken);
+        return rows > 0;
+    }
+}

--- a/src/Shared/Avalon.Common/ValueObjects/PersonalAccessTokenId.cs
+++ b/src/Shared/Avalon.Common/ValueObjects/PersonalAccessTokenId.cs
@@ -1,0 +1,11 @@
+namespace Avalon.Common.ValueObjects;
+
+public class PersonalAccessTokenId : ValueObject<uint>, IHideObjectMembers
+{
+    public PersonalAccessTokenId(uint value) : base(value)
+    {
+    }
+
+    public static implicit operator uint(PersonalAccessTokenId personalAccessTokenId) => personalAccessTokenId.Value;
+    public static implicit operator PersonalAccessTokenId(uint value) => new PersonalAccessTokenId(value);
+}

--- a/src/Shared/Avalon.Domain/Auth/PersonalAccessToken.cs
+++ b/src/Shared/Avalon.Domain/Auth/PersonalAccessToken.cs
@@ -1,0 +1,38 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Avalon.Common.ValueObjects;
+
+namespace Avalon.Domain.Auth;
+
+public class PersonalAccessToken : IDbEntity<PersonalAccessTokenId>
+{
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public PersonalAccessTokenId Id { get; set; } = null!;
+
+    [Required]
+    public AccountId AccountId { get; set; } = null!;
+
+    [Required, MaxLength(128)]
+    public string Name { get; set; } = "";
+
+    [Required]
+    public byte[] TokenHash { get; set; } = Array.Empty<byte>();
+
+    [Required, MaxLength(16)]
+    public string TokenPrefix { get; set; } = "";
+
+    [Required]
+    public AccountAccessLevel Roles { get; set; }
+
+    [Required]
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    public DateTime? ExpiresAt { get; set; }
+
+    public DateTime? LastUsedAt { get; set; }
+
+    public DateTime? RevokedAt { get; set; }
+
+    public AccountId? RevokedBy { get; set; }
+}

--- a/tests/Avalon.Api.UnitTests/Authentication/AvalonAuthenticationHandlerShould.cs
+++ b/tests/Avalon.Api.UnitTests/Authentication/AvalonAuthenticationHandlerShould.cs
@@ -1,0 +1,145 @@
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Encodings.Web;
+using Avalon.Api.Authentication.AV;
+using Avalon.Api.Services;
+using Avalon.Common.ValueObjects;
+using Avalon.Domain.Auth;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Avalon.Api.UnitTests.Authentication;
+
+public class AvalonAuthenticationHandlerShould
+{
+    private readonly IPersonalAccessTokenService _pats = Substitute.For<IPersonalAccessTokenService>();
+    private readonly IAccountService _accounts = Substitute.For<IAccountService>();
+
+    private static readonly AvalonAuthenticationSchemeOptions Options = new();
+
+    private async Task<AuthenticateResult> Authenticate(string? header)
+    {
+        var monitor = Substitute.For<IOptionsMonitor<AvalonAuthenticationSchemeOptions>>();
+        monitor.Get(Arg.Any<string>()).Returns(Options);
+
+        var handler = new AvalonAuthenticationHandler(monitor, NullLoggerFactory.Instance, UrlEncoder.Default, _pats, _accounts);
+        var context = new DefaultHttpContext();
+        if (header is not null) context.Request.Headers["Authorization"] = header;
+
+        var scheme = new AuthenticationScheme("AV", "AV", typeof(AvalonAuthenticationHandler));
+        await handler.InitializeAsync(scheme, context);
+        return await handler.AuthenticateAsync();
+    }
+
+    private static Account MakeAccount(AccountAccessLevel roles = AccountAccessLevel.Player, AccountStatus status = AccountStatus.Active) => new()
+    {
+        Id = new AccountId(7), Username = "u", Email = "u@t",
+        Salt = new byte[] {1}, Verifier = new byte[] {2},
+        JoinDate = DateTime.UtcNow, AccessLevel = roles, Status = status,
+    };
+
+    private static PersonalAccessToken MakePat(string token, AccountAccessLevel roles = AccountAccessLevel.Player,
+        DateTime? expiresAt = null, DateTime? revokedAt = null) => new()
+    {
+        Id = new PersonalAccessTokenId(5),
+        AccountId = new AccountId(7),
+        TokenHash = SHA256.HashData(Encoding.UTF8.GetBytes(token)),
+        Name = "ci",
+        TokenPrefix = token[..8],
+        Roles = roles,
+        CreatedAt = DateTime.UtcNow,
+        ExpiresAt = expiresAt ?? DateTime.UtcNow.AddDays(1),
+        RevokedAt = revokedAt,
+    };
+
+    [Fact] public async Task NoResult_WhenHeaderMissing() =>
+        Assert.False((await Authenticate(null)).Succeeded);
+
+    [Fact]
+    public async Task NoResult_WhenSchemePrefixIsBearer()
+    {
+        var result = await Authenticate("Bearer xyz");
+        Assert.False(result.Succeeded);
+        Assert.Null(result.Failure);
+    }
+
+    [Fact]
+    public async Task Fail_WhenTokenPrefixWrong()
+    {
+        var result = await Authenticate("Avalon not-a-pat");
+        Assert.NotNull(result.Failure);
+    }
+
+    [Fact]
+    public async Task Fail_WhenTokenLengthWrong()
+    {
+        var result = await Authenticate("Avalon avp_short");
+        Assert.NotNull(result.Failure);
+    }
+
+    [Fact]
+    public async Task Fail_WhenTokenUnknown()
+    {
+        var valid = "avp_" + new string('A', 43);
+        _pats.FindByRawTokenAsync(valid, Arg.Any<CancellationToken>()).Returns((PersonalAccessToken?)null);
+
+        var result = await Authenticate("Avalon " + valid);
+        Assert.NotNull(result.Failure);
+    }
+
+    [Fact]
+    public async Task Fail_WhenTokenRevoked()
+    {
+        var token = "avp_" + new string('A', 43);
+        _pats.FindByRawTokenAsync(token, Arg.Any<CancellationToken>())
+             .Returns(MakePat(token, revokedAt: DateTime.UtcNow.AddMinutes(-1)));
+        _accounts.FindByIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>()).Returns(MakeAccount());
+
+        var result = await Authenticate("Avalon " + token);
+        Assert.NotNull(result.Failure);
+    }
+
+    [Fact]
+    public async Task Fail_WhenTokenExpired()
+    {
+        var token = "avp_" + new string('A', 43);
+        _pats.FindByRawTokenAsync(token, Arg.Any<CancellationToken>())
+             .Returns(MakePat(token, expiresAt: DateTime.UtcNow.AddMinutes(-1)));
+
+        var result = await Authenticate("Avalon " + token);
+        Assert.NotNull(result.Failure);
+    }
+
+    [Fact]
+    public async Task Fail_WhenAccountInactive()
+    {
+        var token = "avp_" + new string('A', 43);
+        _pats.FindByRawTokenAsync(token, Arg.Any<CancellationToken>()).Returns(MakePat(token));
+        _accounts.FindByIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>())
+                 .Returns(MakeAccount(status: AccountStatus.Banned));
+
+        var result = await Authenticate("Avalon " + token);
+        Assert.NotNull(result.Failure);
+    }
+
+    [Fact]
+    public async Task Success_WithPatIdClaimAndTokenRoles()
+    {
+        var token = "avp_" + new string('A', 43);
+        _pats.FindByRawTokenAsync(token, Arg.Any<CancellationToken>()).Returns(MakePat(token, AccountAccessLevel.Player));
+        _accounts.FindByIdAsync(Arg.Any<AccountId>(), Arg.Any<CancellationToken>()).Returns(MakeAccount(AccountAccessLevel.Admin));
+
+        var result = await Authenticate("Avalon " + token);
+
+        Assert.True(result.Succeeded);
+        Assert.Contains(result.Principal!.Claims, c => c.Type == "pat_id" && c.Value == "5");
+        Assert.Contains(result.Principal.Claims, c => c.Type == ClaimTypes.GroupSid && c.Value == "Player");
+        // Token roles (Player) NOT account roles (Admin) — crucial.
+        Assert.DoesNotContain(result.Principal.Claims, c => c.Type == ClaimTypes.GroupSid && c.Value == "Admin");
+    }
+}

--- a/tests/Avalon.Api.UnitTests/Authorization/PatReadHandlerShould.cs
+++ b/tests/Avalon.Api.UnitTests/Authorization/PatReadHandlerShould.cs
@@ -1,0 +1,52 @@
+using System.Security.Claims;
+using Avalon.Api.Authentication;
+using Avalon.Api.Authorization;
+using Avalon.Common.ValueObjects;
+using Avalon.Domain.Auth;
+using Microsoft.AspNetCore.Authorization;
+using Xunit;
+
+namespace Avalon.Api.UnitTests.Authorization;
+
+public class PatReadHandlerShould
+{
+    private readonly PatReadHandler _sut = new();
+
+    private static PersonalAccessToken MakePat(long ownerAccountId) => new()
+    {
+        Id = new PersonalAccessTokenId(1),
+        AccountId = new AccountId(ownerAccountId),
+        TokenHash = new byte[] { 0x00 },
+        TokenPrefix = "avp_abcd",
+        Name = "t",
+        Roles = AccountAccessLevel.Player,
+        CreatedAt = DateTime.UtcNow,
+    };
+
+    private static ClaimsPrincipal User(long accountId, params string[] roles)
+    {
+        var claims = new List<Claim> { new(ClaimTypes.NameIdentifier, accountId.ToString()) };
+        claims.AddRange(roles.Select(r => new Claim(ClaimTypes.Role, r)));
+        return new(new ClaimsIdentity(claims, "test", ClaimTypes.NameIdentifier, ClaimTypes.Role));
+    }
+
+    private async Task<bool> Run(ClaimsPrincipal user, PersonalAccessToken resource)
+    {
+        var req = new ReadRequirement();
+        var ctx = new AuthorizationHandlerContext(new[] { req }, user, resource);
+        await _sut.HandleAsync(ctx);
+        return ctx.HasSucceeded;
+    }
+
+    [Fact] public async Task Succeed_WhenCallerIsOwner() =>
+        Assert.True(await Run(User(7, AvalonRoles.Player), MakePat(7)));
+
+    [Fact] public async Task Succeed_WhenCallerIsAdmin() =>
+        Assert.True(await Run(User(99, AvalonRoles.Admin), MakePat(7)));
+
+    [Fact] public async Task Fail_WhenCallerIsGameMasterAndNotOwner() =>
+        Assert.False(await Run(User(99, AvalonRoles.GameMaster), MakePat(7)));
+
+    [Fact] public async Task Fail_WhenCallerIsPlayerAndNotOwner() =>
+        Assert.False(await Run(User(99, AvalonRoles.Player), MakePat(7)));
+}

--- a/tests/Avalon.Api.UnitTests/Authorization/PatWriteHandlerShould.cs
+++ b/tests/Avalon.Api.UnitTests/Authorization/PatWriteHandlerShould.cs
@@ -1,0 +1,52 @@
+using System.Security.Claims;
+using Avalon.Api.Authentication;
+using Avalon.Api.Authorization;
+using Avalon.Common.ValueObjects;
+using Avalon.Domain.Auth;
+using Microsoft.AspNetCore.Authorization;
+using Xunit;
+
+namespace Avalon.Api.UnitTests.Authorization;
+
+public class PatWriteHandlerShould
+{
+    private readonly PatWriteHandler _sut = new();
+
+    private static PersonalAccessToken MakePat(long ownerAccountId) => new()
+    {
+        Id = new PersonalAccessTokenId(1),
+        AccountId = new AccountId(ownerAccountId),
+        TokenHash = new byte[] { 0x00 },
+        TokenPrefix = "avp_abcd",
+        Name = "t",
+        Roles = AccountAccessLevel.Player,
+        CreatedAt = DateTime.UtcNow,
+    };
+
+    private static ClaimsPrincipal User(long accountId, params string[] roles)
+    {
+        var claims = new List<Claim> { new(ClaimTypes.NameIdentifier, accountId.ToString()) };
+        claims.AddRange(roles.Select(r => new Claim(ClaimTypes.Role, r)));
+        return new(new ClaimsIdentity(claims, "test", ClaimTypes.NameIdentifier, ClaimTypes.Role));
+    }
+
+    private async Task<bool> Run(ClaimsPrincipal user, PersonalAccessToken resource)
+    {
+        var req = new WriteRequirement();
+        var ctx = new AuthorizationHandlerContext(new[] { req }, user, resource);
+        await _sut.HandleAsync(ctx);
+        return ctx.HasSucceeded;
+    }
+
+    [Fact] public async Task Succeed_WhenCallerIsOwner() =>
+        Assert.True(await Run(User(7, AvalonRoles.Player), MakePat(7)));
+
+    [Fact] public async Task Succeed_WhenCallerIsAdmin() =>
+        Assert.True(await Run(User(99, AvalonRoles.Admin), MakePat(7)));
+
+    [Fact] public async Task Fail_WhenCallerIsGameMasterAndNotOwner() =>
+        Assert.False(await Run(User(99, AvalonRoles.GameMaster), MakePat(7)));
+
+    [Fact] public async Task Fail_WhenCallerIsPlayerAndNotOwner() =>
+        Assert.False(await Run(User(99, AvalonRoles.Player), MakePat(7)));
+}

--- a/tests/Avalon.Api.UnitTests/Controllers/AccountControllerShould.cs
+++ b/tests/Avalon.Api.UnitTests/Controllers/AccountControllerShould.cs
@@ -156,7 +156,7 @@ public class AccountControllerShould
 
         Assert.IsType<NoContentResult>(result);
         await _accountService.Received(1).UpdateStatusAsync(
-            new AccountId(7), AccountStatus.Banned, "cheat", Arg.Any<CancellationToken>());
+            new AccountId(7), AccountStatus.Banned, "cheat", new AccountId(99), Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/Avalon.Api.UnitTests/Controllers/PersonalAccessTokenControllerShould.cs
+++ b/tests/Avalon.Api.UnitTests/Controllers/PersonalAccessTokenControllerShould.cs
@@ -1,0 +1,268 @@
+using System.Security.Claims;
+using Avalon.Api.Authentication;
+using Avalon.Api.Contract;
+using Avalon.Api.Controllers;
+using Avalon.Api.Services;
+using Avalon.Common.ValueObjects;
+using Avalon.Domain.Auth;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using Xunit;
+
+namespace Avalon.Api.UnitTests.Controllers;
+
+public class PersonalAccessTokenControllerShould
+{
+    private readonly IPersonalAccessTokenService _service = Substitute.For<IPersonalAccessTokenService>();
+    private readonly IAuthorizationService _authz = Substitute.For<IAuthorizationService>();
+
+    private PersonalAccessTokenController MakeSut(ClaimsPrincipal user) =>
+        new(_service, _authz)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext { User = user }
+            }
+        };
+
+    private static ClaimsPrincipal User(long accountId, params string[] roles)
+    {
+        var claims = new List<Claim> { new(ClaimTypes.NameIdentifier, accountId.ToString()) };
+        claims.AddRange(roles.Select(r => new Claim(ClaimTypes.Role, r)));
+        return new(new ClaimsIdentity(claims, "test", ClaimTypes.NameIdentifier, ClaimTypes.Role));
+    }
+
+    private static ClaimsPrincipal UserWithPatId(long accountId, long patId, params string[] roles)
+    {
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, accountId.ToString()),
+            new("pat_id", patId.ToString()),
+        };
+        claims.AddRange(roles.Select(r => new Claim(ClaimTypes.Role, r)));
+        return new(new ClaimsIdentity(claims, "test", ClaimTypes.NameIdentifier, ClaimTypes.Role));
+    }
+
+    private static PersonalAccessToken MakePat(long accountId, uint id = 1) => new()
+    {
+        Id = new PersonalAccessTokenId(id),
+        AccountId = new AccountId(accountId),
+        Name = "my-token",
+        TokenPrefix = "avp_abcd",
+        Roles = AccountAccessLevel.Player,
+        CreatedAt = DateTime.UtcNow,
+        ExpiresAt = DateTime.UtcNow.AddDays(30),
+    };
+
+    private static MintResult MakeMintResult(uint id = 1) =>
+        new(new PersonalAccessTokenId(id), "my-token", "avp_fulltokenvalue", "avp_abcd",
+            DateTime.UtcNow.AddDays(365), AccountAccessLevel.Player);
+
+    [Fact]
+    public async Task Create_Returns403_WhenCallerIsPat()
+    {
+        var user = UserWithPatId(7, 42, AvalonRoles.Player);
+        var sut = MakeSut(user);
+
+        var result = await sut.Create(new CreatePatRequest { Name = "x" }, CancellationToken.None);
+
+        var obj = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(StatusCodes.Status403Forbidden, obj.StatusCode);
+        await _service.DidNotReceive().MintSelfAsync(
+            Arg.Any<AccountId>(), Arg.Any<AccountAccessLevel>(), Arg.Any<string>(),
+            Arg.Any<DateTime?>(), Arg.Any<AccountAccessLevel?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Create_Delegates_WhenCallerIsJwt()
+    {
+        var user = User(7, AvalonRoles.Player);
+        _service.MintSelfAsync(
+            Arg.Any<AccountId>(), Arg.Any<AccountAccessLevel>(), "x",
+            Arg.Any<DateTime?>(), Arg.Any<AccountAccessLevel?>(), Arg.Any<CancellationToken>())
+            .Returns(MakeMintResult(5));
+
+        var sut = MakeSut(user);
+        var result = await sut.Create(new CreatePatRequest { Name = "x" }, CancellationToken.None);
+
+        var created = Assert.IsType<CreatedAtActionResult>(result);
+        var dto = Assert.IsType<PatCreatedDto>(created.Value);
+        Assert.Equal("avp_fulltokenvalue", dto.Token);
+        Assert.Equal(5u, dto.Id);
+        Assert.Equal(7, dto.AccountId);
+        Assert.Equal("avp_abcd", dto.Prefix);
+        await _service.Received(1).MintSelfAsync(
+            Arg.Is<AccountId>(a => a.Value == 7), Arg.Any<AccountAccessLevel>(), "x",
+            Arg.Any<DateTime?>(), Arg.Any<AccountAccessLevel?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task List_ReturnsOwnTokens()
+    {
+        var user = User(7, AvalonRoles.Player);
+        _service.ListByAccountAsync(Arg.Is<AccountId>(a => a.Value == 7), true, Arg.Any<CancellationToken>())
+            .Returns(new List<PersonalAccessToken> { MakePat(7, 1), MakePat(7, 2) });
+
+        var sut = MakeSut(user);
+        var result = await sut.List(CancellationToken.None);
+
+        Assert.Equal(2, result.Count);
+        Assert.All(result, p => Assert.Equal(7, p.AccountId));
+    }
+
+    [Fact]
+    public async Task GetById_Returns404_WhenMissing()
+    {
+        var user = User(7, AvalonRoles.Player);
+        _service.GetAsync(Arg.Any<PersonalAccessTokenId>(), Arg.Any<CancellationToken>())
+            .Returns((PersonalAccessToken?)null);
+
+        var sut = MakeSut(user);
+        var result = await sut.GetById(42, CancellationToken.None);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task GetById_Returns200_WhenAuthzSucceeds()
+    {
+        var user = User(7, AvalonRoles.Player);
+        var pat = MakePat(7, 42);
+        _service.GetAsync(Arg.Any<PersonalAccessTokenId>(), Arg.Any<CancellationToken>()).Returns(pat);
+        _authz.AuthorizeAsync(user, pat, Arg.Any<IEnumerable<IAuthorizationRequirement>>())
+              .Returns(AuthorizationResult.Success());
+
+        var sut = MakeSut(user);
+        var result = await sut.GetById(42, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var dto = Assert.IsType<PatDto>(ok.Value);
+        Assert.Equal(42u, dto.Id);
+        Assert.Equal(7, dto.AccountId);
+    }
+
+    [Fact]
+    public async Task GetById_Returns404_WhenAuthzFailsAndCallerIsPlayer()
+    {
+        var user = User(7, AvalonRoles.Player);
+        var pat = MakePat(99, 42);
+        _service.GetAsync(Arg.Any<PersonalAccessTokenId>(), Arg.Any<CancellationToken>()).Returns(pat);
+        _authz.AuthorizeAsync(user, pat, Arg.Any<IEnumerable<IAuthorizationRequirement>>())
+              .Returns(AuthorizationResult.Failed());
+
+        var sut = MakeSut(user);
+        var result = await sut.GetById(42, CancellationToken.None);
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task Revoke_Delegates_WhenAuthzSucceeds()
+    {
+        var user = User(7, AvalonRoles.Player);
+        var pat = MakePat(7, 42);
+        _service.GetAsync(Arg.Any<PersonalAccessTokenId>(), Arg.Any<CancellationToken>()).Returns(pat);
+        _authz.AuthorizeAsync(user, pat, Arg.Any<IEnumerable<IAuthorizationRequirement>>())
+              .Returns(AuthorizationResult.Success());
+
+        var sut = MakeSut(user);
+        var result = await sut.Revoke(42, CancellationToken.None);
+
+        Assert.IsType<NoContentResult>(result);
+        await _service.Received(1).RevokeAsync(pat,
+            Arg.Is<AccountId>(a => a.Value == 7), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Revoke_Returns404_WhenMissing()
+    {
+        var user = User(7, AvalonRoles.Player);
+        _service.GetAsync(Arg.Any<PersonalAccessTokenId>(), Arg.Any<CancellationToken>())
+            .Returns((PersonalAccessToken?)null);
+
+        var sut = MakeSut(user);
+        var result = await sut.Revoke(42, CancellationToken.None);
+
+        Assert.IsType<NotFoundResult>(result);
+        await _service.DidNotReceive().RevokeAsync(
+            Arg.Any<PersonalAccessToken>(), Arg.Any<AccountId>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CreateAdmin_Returns403_WhenCallerIsPat()
+    {
+        var user = UserWithPatId(99, 1, AvalonRoles.Admin);
+        var sut = MakeSut(user);
+
+        var result = await sut.CreateAdmin(
+            new CreateAdminPatRequest { AccountId = 7, Name = "x", Roles = AccountAccessLevel.Player },
+            CancellationToken.None);
+
+        var obj = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(StatusCodes.Status403Forbidden, obj.StatusCode);
+        await _service.DidNotReceive().MintAdminAsync(
+            Arg.Any<AccountAccessLevel>(), Arg.Any<AccountId>(), Arg.Any<string>(),
+            Arg.Any<DateTime?>(), Arg.Any<AccountAccessLevel>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CreateAdmin_Delegates_WithTargetAccountId()
+    {
+        var user = User(99, AvalonRoles.Admin);
+        _service.MintAdminAsync(
+            Arg.Any<AccountAccessLevel>(), Arg.Is<AccountId>(a => a.Value == 7), "x",
+            Arg.Any<DateTime?>(), AccountAccessLevel.Player, Arg.Any<CancellationToken>())
+            .Returns(MakeMintResult(10));
+
+        var sut = MakeSut(user);
+        var result = await sut.CreateAdmin(
+            new CreateAdminPatRequest { AccountId = 7, Name = "x", Roles = AccountAccessLevel.Player },
+            CancellationToken.None);
+
+        var created = Assert.IsType<CreatedAtActionResult>(result);
+        var dto = Assert.IsType<PatCreatedDto>(created.Value);
+        Assert.Equal(7, dto.AccountId);
+        Assert.Equal("avp_fulltokenvalue", dto.Token);
+        await _service.Received(1).MintAdminAsync(
+            Arg.Any<AccountAccessLevel>(), Arg.Is<AccountId>(a => a.Value == 7), "x",
+            Arg.Any<DateTime?>(), AccountAccessLevel.Player, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RevokeAllForAccount_DelegatesAndReturnsCount()
+    {
+        var user = User(99, AvalonRoles.Admin);
+        _service.RevokeAllForAccountAsync(
+            Arg.Is<AccountId>(a => a.Value == 7),
+            Arg.Is<AccountId>(a => a.Value == 99),
+            Arg.Any<CancellationToken>())
+            .Returns(3);
+
+        var sut = MakeSut(user);
+        var result = await sut.RevokeAllForAccount(7, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.NotNull(ok.Value);
+        await _service.Received(1).RevokeAllForAccountAsync(
+            Arg.Is<AccountId>(a => a.Value == 7),
+            Arg.Is<AccountId>(a => a.Value == 99),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ListAdmin_CallsServiceWithGivenAccountId()
+    {
+        var user = User(99, AvalonRoles.Admin);
+        _service.ListByAccountAsync(Arg.Is<AccountId>(a => a.Value == 7), false, Arg.Any<CancellationToken>())
+            .Returns(new List<PersonalAccessToken> { MakePat(7, 1) });
+
+        var sut = MakeSut(user);
+        var result = await sut.ListAdmin(7, false, CancellationToken.None);
+
+        Assert.Single(result);
+        await _service.Received(1).ListByAccountAsync(
+            Arg.Is<AccountId>(a => a.Value == 7), false, Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Avalon.Api.UnitTests/Services/PersonalAccessTokenServiceShould.cs
+++ b/tests/Avalon.Api.UnitTests/Services/PersonalAccessTokenServiceShould.cs
@@ -1,0 +1,122 @@
+using System.Security.Cryptography;
+using System.Text;
+using Avalon.Api.Exceptions;
+using Avalon.Api.Services;
+using Avalon.Common.ValueObjects;
+using Avalon.Database.Auth.Repositories;
+using Avalon.Domain.Auth;
+using Avalon.Infrastructure.Services;
+using NSubstitute;
+using Xunit;
+
+namespace Avalon.Api.UnitTests.Services;
+
+public class PersonalAccessTokenServiceShould
+{
+    private readonly IPersonalAccessTokenRepository _repo = Substitute.For<IPersonalAccessTokenRepository>();
+    private readonly ISecureRandom _random = Substitute.For<ISecureRandom>();
+    private static readonly DateTimeOffset FixedNow = DateTime.Parse("2026-04-22Z").ToUniversalTime();
+    private readonly TimeProvider _time = new FakeTimeProvider(FixedNow);
+
+    private PersonalAccessTokenService MakeSut() => new(_repo, _random, _time);
+
+    [Fact]
+    public async Task MintSelf_DefaultsRolesToCallerRoles_WhenRequestedRolesOmitted()
+    {
+        _random.GetBytes(32).Returns(Enumerable.Repeat((byte)0xAA, 32).ToArray());
+        _repo.CreateAsync(Arg.Any<PersonalAccessToken>(), Arg.Any<CancellationToken>())
+             .Returns(ci => ci.Arg<PersonalAccessToken>());
+
+        var sut = MakeSut();
+        var result = await sut.MintSelfAsync(
+            callerId: new AccountId(7),
+            callerRoles: AccountAccessLevel.Player | AccountAccessLevel.GameMaster,
+            name: "ci",
+            expiresAt: null,
+            requestedRoles: null,
+            CancellationToken.None);
+
+        Assert.Equal(AccountAccessLevel.Player | AccountAccessLevel.GameMaster, result.Roles);
+        Assert.StartsWith("avp_", result.Token);
+        Assert.Equal(8, result.Prefix.Length);
+    }
+
+    [Fact]
+    public async Task MintSelf_Throws_WhenRequestedRolesSupersetOfCaller()
+    {
+        var sut = MakeSut();
+        await Assert.ThrowsAsync<BusinessException>(() => sut.MintSelfAsync(
+            callerId: new AccountId(7),
+            callerRoles: AccountAccessLevel.Player,
+            name: "ci",
+            expiresAt: null,
+            requestedRoles: AccountAccessLevel.Admin,
+            CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task MintAdmin_AcceptsRolesBeyondTargetButWithinCaller()
+    {
+        _random.GetBytes(32).Returns(new byte[32]);
+        _repo.CreateAsync(Arg.Any<PersonalAccessToken>(), Arg.Any<CancellationToken>())
+             .Returns(ci => ci.Arg<PersonalAccessToken>());
+
+        var sut = MakeSut();
+        var result = await sut.MintAdminAsync(
+            callerRoles: AccountAccessLevel.Admin | AccountAccessLevel.GameMaster | AccountAccessLevel.Player,
+            targetAccountId: new AccountId(7),
+            name: "svc",
+            expiresAt: null,
+            requestedRoles: AccountAccessLevel.GameMaster,
+            CancellationToken.None);
+
+        Assert.Equal(AccountAccessLevel.GameMaster, result.Roles);
+    }
+
+    [Fact]
+    public async Task MintAdmin_Throws_WhenRequestedRolesExceedCaller()
+    {
+        var sut = MakeSut();
+        await Assert.ThrowsAsync<BusinessException>(() => sut.MintAdminAsync(
+            callerRoles: AccountAccessLevel.Admin,
+            targetAccountId: new AccountId(7),
+            name: "svc",
+            expiresAt: null,
+            requestedRoles: AccountAccessLevel.Console,
+            CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Mint_Throws_WhenExpiryBeyondMaxLifetime()
+    {
+        var sut = MakeSut();
+        var tooFar = FixedNow.UtcDateTime.AddDays(400);
+        await Assert.ThrowsAsync<BusinessException>(() => sut.MintSelfAsync(
+            callerId: new AccountId(7),
+            callerRoles: AccountAccessLevel.Player,
+            name: "ci",
+            expiresAt: tooFar,
+            requestedRoles: null,
+            CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task FindByRawToken_HashesAndDelegates()
+    {
+        _repo.FindByHashAsync(Arg.Any<byte[]>(), Arg.Any<CancellationToken>())
+             .Returns((PersonalAccessToken?)null);
+
+        var sut = MakeSut();
+        await sut.FindByRawTokenAsync("avp_abcdef", CancellationToken.None);
+
+        var expected = SHA256.HashData(Encoding.UTF8.GetBytes("avp_abcdef"));
+        await _repo.Received(1).FindByHashAsync(
+            Arg.Is<byte[]>(h => h.SequenceEqual(expected)),
+            Arg.Any<CancellationToken>());
+    }
+}
+
+internal sealed class FakeTimeProvider(DateTimeOffset now) : TimeProvider
+{
+    public override DateTimeOffset GetUtcNow() => now;
+}


### PR DESCRIPTION
## Summary

Stacked on top of #193. Implements the Personal Access Token subsystem, replacing the stub `AvalonAuthenticationHandler` with real PAT validation.

- **Token format:** `avp_<base64url(32 random bytes)>` — 256-bit entropy, 47 chars total, prefix grep-able for leak scanners.
- **Storage:** `PersonalAccessToken` entity + `personal_access_tokens` table in `AuthDbContext`. Unique index on SHA-256 `TokenHash`, composite index on `(AccountId, RevokedAt)`, FK to `Accounts(Id)` with `ON DELETE CASCADE`.
- **Auth scheme:** `"Avalon"` bearer header (`Authorization: Avalon <token>`) — existing scheme name preserved. Handler does format check → DB hash lookup → revoked/expired/inactive checks → builds `ClaimsPrincipal` from **token's** roles (not account's current roles).
- **Service:** `IPersonalAccessTokenService` with mint (self + admin), revoke, find-by-hash, write-coalesced `TouchLastUsed` (1 minute bucket).
- **Controller at `/pat`:**
  - Self (Player+): `POST`, `GET`, `GET {id}`, `DELETE {id}`.
  - Admin: `POST /pat/admin`, `GET /pat/admin?accountId=&includeRevoked=`, `DELETE /pat/admin/account/{id}`.
  - `pat_id` claim presence guards against PAT-can't-mint-PAT (403).
- **Resource authz:** `PatReadHandler` + `PatWriteHandler` — both require **Admin+ or owner** (Read does NOT fall back to GameMaster; PATs are sensitive).
- **Ban integration:** `PATCH /account/{id}/status = Banned` now wraps status update + bulk PAT revocation in a single DB transaction; Redis disconnect publish runs only after commit.

## Security notes

- Raw token returned once on `POST /pat` only (`PatCreatedDto`); list/get use `PatDto` which has no `Token` field.
- SHA-256 unsalted on random 256-bit tokens — no rainbow-table concern.
- PAT roles locked at mint; post-mint role changes on the account don't retroactively extend an existing PAT.
- Admin-mint enforces `requestedRoles ⊆ callerRoles` — Admin cannot mint a Console-role PAT.
- Banning an account atomically revokes all live PATs before disconnect signal.

## Test plan

- [x] 562 unit tests passing (35 new: service 6, auth handler 9, pat handlers 8, controller 12).
- [x] Build clean.
- [ ] Manual: mint PAT, call `/character/{id}` with `Authorization: Avalon <token>`, verify behaves identically to JWT.
- [ ] Manual: revoke PAT, verify subsequent call returns 401.
- [ ] Manual: ban an account with live PAT, verify PAT stops working + world disconnect fires.
- [ ] Manual: attempt to mint PAT using a PAT-authenticated principal — expect 403.

## Notes

Depends on #192 (authz primitives) and #193 (ban-status endpoint + DI).