### PR TITLE
fix(combat): use ability AnimationId in attack-animation broadcast

### DIFF
--- a/src/Server/Avalon.World/Instances/MapInstance.cs
+++ b/src/Server/Avalon.World/Instances/MapInstance.cs
@@ -467,12 +467,23 @@ public class MapInstance : IMapInstance, IPortalSink
             return;
         }
 
+        ushort animationId = ResolveBroadcastAnimationId(spell);
         foreach ((ObjectGuid guid, IWorldConnection connection) in _connections)
         {
-            connection.Send(SUnitAttackAnimationPacket.Create(attacker.Guid, 1,
+            connection.Send(SUnitAttackAnimationPacket.Create(attacker.Guid, animationId,
                 connection.CryptoSession.Encrypt));
         }
     }
+
+    /// <summary>
+    /// Pure helper, exposed for unit tests. Returns the AnimationId the broadcast
+    /// should carry: the ability's metadata AnimationId, or 1 (legacy default for melee
+    /// auto-attacks) when no ability backs the swing.
+    /// AbilityMetadata stores AnimationId as uint; the wire packet field is ushort
+    /// (animation IDs are practically &lt;= 65535).
+    /// </summary>
+    public static ushort ResolveBroadcastAnimationId(IAbility? ability)
+        => (ushort)(ability?.Metadata.AnimationId ?? 1u);
 
     private void BroadcastFinishCastAnimation(IUnit attacker, IAbility spell)
     {

--- a/tests/Avalon.Server.World.UnitTests/Instances/MapInstanceBroadcastAnimationIdShould.cs
+++ b/tests/Avalon.Server.World.UnitTests/Instances/MapInstanceBroadcastAnimationIdShould.cs
@@ -1,0 +1,44 @@
+using Avalon.Common.ValueObjects;
+using Avalon.World.Instances;
+using Avalon.World.Public.Abilities;
+using NSubstitute;
+using Xunit;
+
+namespace Avalon.Server.World.UnitTests.Instances;
+
+public class MapInstanceBroadcastAnimationIdShould
+{
+    [Fact]
+    public void Return_metadata_animation_id_when_ability_present()
+    {
+        var ability = Substitute.For<IAbility>();
+        ability.Metadata.Returns(new AbilityMetadata { AnimationId = 5u });
+
+        ushort result = MapInstance.ResolveBroadcastAnimationId(ability);
+
+        Assert.Equal((ushort)5, result);
+    }
+
+    [Fact]
+    public void Return_zero_when_metadata_animation_id_is_zero()
+    {
+        // Basic-attack ability templates seed AnimationId=0 on purpose; the broadcast must
+        // honour that (client treats 0 as "no animation"), not silently fall back to 1.
+        var ability = Substitute.For<IAbility>();
+        ability.Metadata.Returns(new AbilityMetadata { AnimationId = 0u });
+
+        ushort result = MapInstance.ResolveBroadcastAnimationId(ability);
+
+        Assert.Equal((ushort)0, result);
+    }
+
+    [Fact]
+    public void Fall_back_to_one_when_ability_is_null()
+    {
+        // Null ability == legacy melee auto-attack swing (no ability backing). The historic
+        // hardcoded broadcast value was 1; preserve that as the fallback.
+        ushort result = MapInstance.ResolveBroadcastAnimationId(null);
+
+        Assert.Equal((ushort)1, result);
+    }
+}


### PR DESCRIPTION
## Summary

`MapInstance.BroadcastUnitAttackAnimation` hardcoded `animationId = 1` regardless of the spell being cast. PR #217 added the `AnimationId` column to `AbilityTemplate`/`AbilityMetadata` (closing #161) but never wired it into the broadcast.

This PR completes the chain:
- Extracts `MapInstance.ResolveBroadcastAnimationId(IAbility?)` — returns `spell.Metadata.AnimationId` when an ability backs the swing, falls back to `1` (legacy auto-attack default) when null.
- Casts to `ushort` (`SUnitAttackAnimationPacket.AnimationId` is `ushort`; `AbilityMetadata.AnimationId` is `uint`).
- `BroadcastFinishCastAnimation` already passes `spell.AbilityId` (issue body's mention of it was stale); no change needed there.

Closes #162.

## Test plan

- [x] `dotnet build` clean.
- [x] New unit tests: `MapInstanceBroadcastAnimationIdShould` — 3/3 passing.
  - `Return_metadata_animation_id_when_ability_present` — packet carries the ability's configured value (e.g. 5).
  - `Return_zero_when_metadata_animation_id_is_zero` — basic-attack abilities seed `AnimationId=0`; broadcast must honour that (client treats 0 as "no animation"), not silently fall back to 1.
  - `Fall_back_to_one_when_ability_is_null` — legacy null-ability swing keeps the historic default.